### PR TITLE
Using Azure App Configuration for storing configuration settings.

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="3.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.7" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.17.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
@@ -1,6 +1,8 @@
-﻿using Equinor.ProCoSys.IPO.WebApi.Misc;
+﻿using System;
+using Azure.Identity;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Hosting;
 
 namespace Equinor.ProCoSys.IPO.WebApi
@@ -17,11 +19,24 @@ namespace Equinor.ProCoSys.IPO.WebApi
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, config) =>
                 {
-                    var kvSettings = new KeyVaultSettings();
-                    config.Build().GetSection("KeyVault").Bind(kvSettings);
-                    if (kvSettings.Enabled)
+                    var settings = config.Build();
+                    if (settings.GetValue<bool>("UseAzureAppConfiguration"))
                     {
-                        config.AddAzureKeyVault(kvSettings.Uri, kvSettings.ClientId, kvSettings.ClientSecret);
+                        config.AddAzureAppConfiguration(options =>
+                        {
+                            options.Connect(settings["ConnectionStrings:AppConfig"])
+                                    .ConfigureKeyVault(kv =>
+                                    {
+                                        kv.SetCredential(new DefaultAzureCredential());
+                                    })
+                                    .ConfigureRefresh(options =>
+                                    {
+                                        options.Register("Sentinel", true);
+                                        options.SetCacheExpiration(TimeSpan.FromMinutes(5));
+                                    })
+                                    .Select(KeyFilter.Any, LabelFilter.Null)
+                                    .Select(KeyFilter.Any, context.HostingEnvironment.EnvironmentName);
+                        });
                     }
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.Development.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.Development.json
@@ -7,8 +7,5 @@
     }
   },
   "MigrateDatabase": true,
-  "SeedDummyData": false,
-  "Synchronization": {
-    "Interval": "1:0:0"
-  }
+  "SeedDummyData": false
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.QP.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.QP.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  }
-}

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.Test.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.Test.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  }
-}

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
@@ -4,77 +4,8 @@
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
-    },
-    "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information"
-      }
     }
   },
   "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "IPOContext": ""
-  },
-  "API": {
-    "Authority": "",
-    "Audience": ""
-  },
-  "Swagger": {
-    "AuthorizationUrl": "",
-    "ClientId": "",
-    "Scopes": {}
-  },
-  "ApplicationInsights": {
-    "InstrumentationKey": ""
-  },
-  "MainApi": {
-    "BaseAddress": "",
-    "ApiVersion": "",
-    "TagSearchPageSize": 1000
-  },
-  "AttachmentOptions": {
-    "MaxSizeMb": 100,
-    "BlobClockSkewMinutes": 3,
-    "ValidFileSuffixes": [
-      ".txt",
-      ".jpg",
-      ".jpeg",
-      ".png",
-      ".gif",
-      ".pdf",
-      ".doc",
-      ".docx",
-      ".ppt",
-      ".pptx",
-      ".xls",
-      ".xlsx",
-      ".msg"
-    ],
-    "BlobContainer": "IPO"
-  },
-  "CacheOptions": {
-    "PermissionCacheMinutes": 20,
-    "PlantCacheMinutes": 20
-  },
-  "BlobStorage": {
-    "ConnectionString": ""
-  },
-  "KeyVault": {
-    "ClientId": "",
-    "ClientSecret": "",
-    "Uri": "",
-    "Enabled": false
-  },
-  "Authenticator": {
-    "Instance": "",
-    "IPOApiClientId": "",
-    "IPOApiSecret": "",
-    "MainApiClientId": "",
-    "MainApiSecret": "",
-    "MainApiScope": ""
-  },
-  "Synchronization": {
-    "UserOid": "",
-    "Interval": "1:0:0"
-  }
+  "UseAzureAppConfiguration": true
 }


### PR DESCRIPTION
This means that there is one central place to set all configuration per environment. If a different, local configuration setup is needed, the settings can be exported and stored locally, and Azure App Configuration can be disabled.