### PR TITLE
App insights

### DIFF
--- a/pipelines/api-build.yml
+++ b/pipelines/api-build.yml
@@ -124,7 +124,7 @@ stages:
 - stage: test
   displayName: 'Test'
   dependsOn: 'dev'
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: succeeded()
   variables:
     env: 'test'
     envName: 'non-prod'

--- a/pipelines/api-build.yml
+++ b/pipelines/api-build.yml
@@ -76,7 +76,7 @@ stages:
 - stage: dev
   displayName: 'Dev'
   dependsOn: 'common'
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: succeeded()
   variables:
     env: 'dev'
     envName: 'non-prod'

--- a/pipelines/api-build.yml
+++ b/pipelines/api-build.yml
@@ -41,7 +41,7 @@ stages:
     parameters:
       deploymentName: 'docker_build'
       dependsOn: ''
-      condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(always(), eq(variables['Build.Reason'], 'PullRequest'))
       envGroup: '${{ variables.envGroupName }}'
       buildCommand: build
       versionNumber: ${{ variables.versionNumber }}
@@ -55,7 +55,7 @@ stages:
     parameters:
       deploymentName: 'docker_build_and_push_master_only'
       dependsOn: ''
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(always(), ne(variables['Build.Reason'], 'PullRequest'))
       envGroup: '${{ variables.envGroupName }}'
       buildCommand: buildAndPush
       versionNumber: ${{ variables.versionNumber }}

--- a/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
@@ -11,7 +11,6 @@ namespace Equinor.ProCoSys.IPO.WebApi
     {
         public static void Main(string[] args)
         {
-            Environment.SetEnvironmentVariable("ApplicationInsights--InstrumentationKey", null);
             var host = CreateHostBuilder(args).Build();
             host.Run();
         }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
@@ -11,7 +11,7 @@ namespace Equinor.ProCoSys.IPO.WebApi
     {
         public static void Main(string[] args)
         {
-            Environment.SetEnvironmentVariable("ApplicationInsights:InstrumentationKey", null);
+            Environment.SetEnvironmentVariable("ApplicationInsights--InstrumentationKey", null);
             var host = CreateHostBuilder(args).Build();
             host.Run();
         }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Program.cs
@@ -11,6 +11,7 @@ namespace Equinor.ProCoSys.IPO.WebApi
     {
         public static void Main(string[] args)
         {
+            Environment.SetEnvironmentVariable("ApplicationInsights:InstrumentationKey", null);
             var host = CreateHostBuilder(args).Build();
             host.Run();
         }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Startup.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Startup.cs
@@ -154,7 +154,7 @@ namespace Equinor.ProCoSys.IPO.WebApi
                 options.DisableClaimsTransformation();                                  // Disable this - Fusion adds relevant claims
             });
 
-            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetry(Configuration["ApplicationInsights:InstrumentationKey"]);
             services.AddMediatrModules();
             services.AddApplicationModules(Configuration);
         }


### PR DESCRIPTION
Reading Application Insights Instrumentation Key from config instead of writing it to environment variable on deploy.
Changed pipeline to build PR branches and to build and deploy all other branches. Only master branch is automatically triggered.