### PR TITLE
78040 - Get ipo details

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -83,7 +83,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
 
         private List<BuilderParticipant> AddFunctionalRoleParticipant(
             Invitation invitation,
-            List<BuilderParticipant> participants, 
+            List<BuilderParticipant> participants,
             ParticipantsForCommand participant)
         {
             if (!participant.FunctionalRole.UsePersonalEmail)
@@ -102,21 +102,22 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                     new ParticipantIdentifier(participant.FunctionalRole.Email)));
             }
 
-            foreach (var p in participant.FunctionalRole.Persons)
+            foreach (var person in participant.FunctionalRole.Persons)
             {
                 participants = AddPersonParticipant(
                     invitation,
                     participants,
-                    p,
+                    person,
                     participant.Organization,
-                    participant.SortKey);
+                    participant.SortKey,
+                    participant.FunctionalRole.Code);
             }
             return participants;
         }
 
         private List<BuilderParticipant> AddPersonParticipant(
             Invitation invitation,
-            List<BuilderParticipant> participants, 
+            List<BuilderParticipant> participants,
             PersonForCommand person,
             Organization organization,
             int sortKey,
@@ -125,7 +126,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             invitation.AddParticipant(new Participant(
                 _plantProvider.Plant,
                 organization,
-                functionalRoleCode != null ? IpoParticipantType.FunctionalRole : IpoParticipantType.Person,
+                IpoParticipantType.Person,
                 functionalRoleCode,
                 person.FirstName,
                 person.LastName,
@@ -147,8 +148,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         }
 
         private List<BuilderParticipant> AddExternalParticipant(
-            Invitation invitation, 
-            List<BuilderParticipant> participants, 
+            Invitation invitation,
+            List<BuilderParticipant> participants,
             ParticipantsForCommand participant)
         {
             invitation.AddParticipant(new Participant(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -102,6 +102,20 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                     new ParticipantIdentifier(participant.FunctionalRole.Email)));
             }
 
+            else
+            {
+                invitation.AddParticipant(new Participant(
+                    _plantProvider.Plant,
+                    participant.Organization,
+                    IpoParticipantType.FunctionalRole,
+                    participant.FunctionalRole.Code,
+                    null,
+                    null,
+                    null,
+                    null,
+                    participant.SortKey));
+            }
+
             foreach (var person in participant.FunctionalRole.Persons)
             {
                 participants = AddPersonParticipant(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -55,9 +55,9 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 if (participant.Person != null)
                 {
                     participants = AddPersonParticipant(
-                        invitation, 
-                        participants, 
-                        participant.Person, 
+                        invitation,
+                        participants,
+                        participant.Person,
                         participant.Organization,
                         participant.SortKey);
                 }
@@ -68,22 +68,17 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 }
             }
 
-            await _unitOfWork.SaveChangesAsync(cancellationToken);
             try
             {
                 var meetingId = await CreateOutlookMeeting(request, participants);
                 invitation.MeetingId = meetingId;
-                await _unitOfWork.SaveChangesAsync(cancellationToken);
-
-                return new SuccessResult<int>(invitation.Id);
             }
             catch
             {
-                _invitationRepository.Remove(invitation);
-                await _unitOfWork.SaveChangesAsync(cancellationToken);
-
                 return new UnexpectedResult<int>("Error: Could not create outlook meeting.");
             }
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return new SuccessResult<int>(invitation.Id);
         }
 
         private List<BuilderParticipant> AddFunctionalRoleParticipant(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -32,7 +32,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         public async Task<Result<int>> Handle(CreateInvitationCommand request, CancellationToken cancellationToken)
         {
             var participants = new List<BuilderParticipant>();
-            var invitation = new Invitation(_plantProvider.Plant, request.ProjectName, request.Title, request.Type);
+            var invitation = new Invitation(_plantProvider.Plant, request.ProjectName, request.Title, request.Description, request.Type);
             _invitationRepository.Add(invitation);
 
             if (request.CommPkgScope.Count > 0)

--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
@@ -11,6 +11,7 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
     {
         public const int ProjectNameMaxLength = 512;
         public const int TitleMaxLength = 1024;
+        public const int DescriptionMaxLength = 4096;
 
         private readonly List<McPkg> _mcPkgs = new List<McPkg>();
         private readonly List<CommPkg> _commPkgs = new List<CommPkg>();
@@ -23,15 +24,17 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
         {
         }
 
-        public Invitation(string plant, string projectName, string title, DisciplineType type)
+        public Invitation(string plant, string projectName, string title, string description, DisciplineType type)
             : base(plant)
         {
             ProjectName = projectName;
             Title = title;
+            Description = description;
             Type = type;
         }
         public string ProjectName { get; set; }
         public string Title { get; set; }
+        public string Description { get; set; }
         public DisciplineType Type { get; set; }
         public IReadOnlyCollection<McPkg> McPkgs => _mcPkgs.AsReadOnly();
         public IReadOnlyCollection<CommPkg> CommPkgs => _commPkgs.AsReadOnly();

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/EntityConfigurations/InvitationConfiguration.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/EntityConfigurations/InvitationConfiguration.cs
@@ -25,6 +25,9 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.EntityConfigurations
                 .HasMaxLength(Invitation.TitleMaxLength)
                 .IsRequired();
 
+            builder.Property(x => x.Description)
+                .HasMaxLength(Invitation.DescriptionMaxLength);
+
             builder
                 .HasMany(x => x.McPkgs)
                 .WithOne()

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201027113031_AddDescriptionToInvitation.Designer.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201027113031_AddDescriptionToInvitation.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.ProCoSys.IPO.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
 {
     [DbContext(typeof(IPOContext))]
-    partial class IPOContextModelSnapshot : ModelSnapshot
+    [Migration("20201027113031_AddDescriptionToInvitation")]
+    partial class AddDescriptionToInvitation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201027113031_AddDescriptionToInvitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201027113031_AddDescriptionToInvitation.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
+{
+    public partial class AddDescriptionToInvitation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Invitations",
+                maxLength: 4096,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Invitations");
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/CommPkgScopeDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/CommPkgScopeDto.cs
@@ -1,0 +1,19 @@
+﻿namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
+{
+    public class CommPkgScopeDto
+    {
+        public CommPkgScopeDto(
+            string commPkgNo,
+            string description,
+            string status)
+        {
+            CommPkgNo = commPkgNo;
+            Description = description;
+            Status = status;
+        }
+
+        public string CommPkgNo { get; }
+        public string Description { get; }
+        public string Status { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ExternalEmailDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ExternalEmailDto.cs
@@ -1,4 +1,6 @@
-﻿namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
+﻿using Fusion.Integration.Meeting;
+
+namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 {
     public class ExternalEmailDto
     {
@@ -12,5 +14,6 @@
 
         public int Id { get; }
         public string ExternalEmail { get; }
+        public OutlookResponse? Response { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ExternalEmailDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ExternalEmailDto.cs
@@ -6,14 +6,17 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
     {
         public ExternalEmailDto(
             int id,
-            string externalEmail)
+            string externalEmail,
+            string rowVersion)
         {
             Id = id;
             ExternalEmail = externalEmail;
+            RowVersion = rowVersion;
         }
 
         public int Id { get; }
         public string ExternalEmail { get; }
         public OutlookResponse? Response { get; set; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ExternalEmailDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ExternalEmailDto.cs
@@ -1,0 +1,16 @@
+﻿namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
+{
+    public class ExternalEmailDto
+    {
+        public ExternalEmailDto(
+            int id,
+            string externalEmail)
+        {
+            Id = id;
+            ExternalEmail = externalEmail;
+        }
+
+        public int Id { get; }
+        public string ExternalEmail { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
@@ -8,11 +8,13 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public FunctionalRoleDto(
             string code,
             string email,
-            IEnumerable<PersonDto> persons)
+            IEnumerable<PersonDto> persons,
+            string rowVersion)
         {
             Code = code;
             Email = email;
             Persons = persons;
+            RowVersion = rowVersion;
         }
 
         public int Id { get; set; }
@@ -20,5 +22,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public string Email { get; }
         public IEnumerable<PersonDto> Persons { get; }
         public OutlookResponse? Response { get; set; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
@@ -14,6 +14,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             Persons = persons;
         }
 
+        public int Id { get; set; }
         public string Code { get; }
         public string Email { get; }
         public IEnumerable<PersonDto> Persons { get; }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
+{
+    public class FunctionalRoleDto
+    {
+        public FunctionalRoleDto(
+            string code,
+            string email,
+            IEnumerable<PersonDto> persons)
+        {
+            Code = code;
+            Email = email;
+            Persons = persons;
+        }
+
+        public string Code { get; }
+        public string Email { get; }
+        public IEnumerable<PersonDto> Persons { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Fusion.Integration.Meeting;
 
 namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 {
@@ -17,6 +18,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public int Id { get; set; }
         public string Code { get; }
         public string Email { get; }
+        public OutlookResponse? Response { get; set; }
         public IEnumerable<PersonDto> Persons { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/FunctionalRoleDto.cs
@@ -18,7 +18,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public int Id { get; set; }
         public string Code { get; }
         public string Email { get; }
-        public OutlookResponse? Response { get; set; }
         public IEnumerable<PersonDto> Persons { get; }
+        public OutlookResponse? Response { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQuery.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQuery.cs
@@ -5,10 +5,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 {
     public class GetInvitationByIdQuery : IRequest<Result<InvitationDto>>
     {
-        public GetInvitationByIdQuery(int id)
-        {
-            Id = id;
-        }
+        public GetInvitationByIdQuery(int id) => Id = id;
 
         public int Id { get; }
     }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -82,12 +82,12 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         .Where(p => p.FunctionalRoleCode == participant.FunctionalRoleCode 
                          && p.Type == IpoParticipantType.Person);
 
-                    yield return new ParticipantDto(participant.Organization, participant.SortKey, participant.Email,
+                    yield return new ParticipantDto(participant.Organization, participant.SortKey, new ExternalEmailDto(participant.Id, participant.Email),
                         null, ConvertToFunctionalRoleDto(participant, personsInFunctionalRole));
                 }
                 else if (ParticipantIsNotInFunctionalRole(participant))
                 {
-                    yield return new ParticipantDto(participant.Organization, participant.SortKey, participant.Email,
+                    yield return new ParticipantDto(participant.Organization, participant.SortKey, new ExternalEmailDto(participant.Id, participant.Email),
                         ConvertToPersonDto(participant), null);
                 }
             }
@@ -96,7 +96,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         private static bool ParticipantIsNotInFunctionalRole(Participant participant) => string.IsNullOrWhiteSpace(participant.FunctionalRoleCode);
 
         private static FunctionalRoleDto ConvertToFunctionalRoleDto(Participant participant, IEnumerable<Participant> personsInFunctionalRole)
-            => new FunctionalRoleDto(participant.FunctionalRoleCode, participant.Email, ConvertToPersonDto(personsInFunctionalRole));
+            => new FunctionalRoleDto(participant.FunctionalRoleCode, participant.Email, ConvertToPersonDto(personsInFunctionalRole)) {Id = participant.Id};
 
         private static PersonDto ConvertToPersonDto(Participant participant)
             => new PersonDto(participant.Id, participant.FirstName, participant.LastName, participant.AzureOid.ToString(), participant.Email);

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,10 +37,14 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             }
 
             var meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId, query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
+            if (meeting == null)
+            {
+                throw new Exception($"Could not get meeting with id {invitation.MeetingId} from Fusion");
+            }
 
-            var invitationResult = ConvertToInvitationDto(invitation, meeting);
+            var invitationDto = ConvertToInvitationDto(invitation, meeting);
 
-            return new SuccessResult<InvitationDto>(invitationResult);
+            return new SuccessResult<InvitationDto>(invitationDto);
         }
 
         private static InvitationDto ConvertToInvitationDto(Invitation invitation, GeneralMeeting meeting)

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -54,7 +54,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 invitation.Title,
                 invitation.Description,
                 meeting.Location,
-                invitation.Type)
+                invitation.Type,
+                invitation.RowVersion.ConvertToString())
             {
                 StartTime = meeting.StartDate.DatetimeUtc,
                 EndTime = meeting.EndDate.DatetimeUtc,
@@ -122,17 +123,17 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                          && p.Type == IpoParticipantType.Person);
 
                     participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey, null,
-                        null, ConvertToFunctionalRoleDto(participant, personsInFunctionalRole)));
+                        null, ConvertToFunctionalRoleDto(participant, personsInFunctionalRole), participant.RowVersion.ConvertToString()));
                 }
                 else if (ParticipantIsNotInFunctionalRole(participant) && participant.Organization != Organization.External)
                 {
                     participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey, null,
-                        ConvertToPersonDto(participant), null));
+                        ConvertToPersonDto(participant), null, participant.RowVersion.ConvertToString()));
                 }
                 else if (participant.Organization == Organization.External)
                 {
                     participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey, new ExternalEmailDto(participant.Id, participant.Email),
-                        ConvertToPersonDto(participant), null));
+                        ConvertToPersonDto(participant), null, participant.RowVersion.ConvertToString()));
                 }
             }
 

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -129,17 +129,19 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                          && p.Type == IpoParticipantType.Person);
 
                     participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey, null,
-                        null, ConvertToFunctionalRoleDto(participant, personsInFunctionalRole), participant.RowVersion.ConvertToString()));
+                        null, ConvertToFunctionalRoleDto(participant, personsInFunctionalRole)));
                 }
                 else if (ParticipantIsNotInFunctionalRole(participant) && participant.Organization != Organization.External)
                 {
                     participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey, null,
-                        ConvertToPersonDto(participant), null, participant.RowVersion.ConvertToString()));
+                        ConvertToPersonDto(participant), null));
                 }
                 else if (participant.Organization == Organization.External)
                 {
-                    participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey, new ExternalEmailDto(participant.Id, participant.Email),
-                        ConvertToPersonDto(participant), null, participant.RowVersion.ConvertToString()));
+                    participantDtos.Add(new ParticipantDto(participant.Organization, participant.SortKey,
+                        new ExternalEmailDto(participant.Id, participant.Email,
+                            participant.RowVersion.ConvertToString()),
+                        ConvertToPersonDto(participant), null));
                 }
             }
 
@@ -149,10 +151,10 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         private static bool ParticipantIsNotInFunctionalRole(Participant participant) => string.IsNullOrWhiteSpace(participant.FunctionalRoleCode);
 
         private static FunctionalRoleDto ConvertToFunctionalRoleDto(Participant participant, IEnumerable<Participant> personsInFunctionalRole)
-            => new FunctionalRoleDto(participant.FunctionalRoleCode, participant.Email, ConvertToPersonDto(personsInFunctionalRole)) {Id = participant.Id};
+            => new FunctionalRoleDto(participant.FunctionalRoleCode, participant.Email, ConvertToPersonDto(personsInFunctionalRole), participant.RowVersion.ConvertToString()) {Id = participant.Id};
 
         private static PersonDto ConvertToPersonDto(Participant participant)
-            => new PersonDto(participant.Id, participant.FirstName, participant.LastName, participant.AzureOid.ToString(), participant.Email);
+            => new PersonDto(participant.Id, participant.FirstName, participant.LastName, participant.AzureOid.ToString(), participant.Email, participant.RowVersion.ConvertToString());
 
         private static IEnumerable<PersonDto> ConvertToPersonDto(IEnumerable<Participant> personsInFunctionalRole) 
             => personsInFunctionalRole.Select(ConvertToPersonDto).ToList();

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -82,10 +82,15 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         .Where(p => p.FunctionalRoleCode == participant.FunctionalRoleCode 
                          && p.Type == IpoParticipantType.Person);
 
-                    yield return new ParticipantDto(participant.Organization, participant.SortKey, new ExternalEmailDto(participant.Id, participant.Email),
+                    yield return new ParticipantDto(participant.Organization, participant.SortKey, null,
                         null, ConvertToFunctionalRoleDto(participant, personsInFunctionalRole));
                 }
-                else if (ParticipantIsNotInFunctionalRole(participant))
+                else if (ParticipantIsNotInFunctionalRole(participant) && participant.Organization != Organization.External)
+                {
+                    yield return new ParticipantDto(participant.Organization, participant.SortKey, null,
+                        ConvertToPersonDto(participant), null);
+                }
+                else if (participant.Organization == Organization.External)
                 {
                     yield return new ParticipantDto(participant.Organization, participant.SortKey, new ExternalEmailDto(participant.Id, participant.Email),
                         ConvertToPersonDto(participant), null);

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -79,13 +79,17 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                     participant.Person.Response = participantPersonResponse;
                 }
 
-                foreach (var personInFunctionalRole in participant.FunctionalRole.Persons)
+                if (participant.FunctionalRole?.Persons != null)
                 {
-                    var participantType = GetParticipantTypeByEmail(meeting, personInFunctionalRole.Email);
-                    personInFunctionalRole.Required = participantType.Equals(ParticipantType.Required);
+                    foreach (var personInFunctionalRole in participant.FunctionalRole?.Persons)
+                    {
+                        var participantType = GetParticipantTypeByEmail(meeting, personInFunctionalRole.Email);
+                        personInFunctionalRole.Required = participantType.Equals(ParticipantType.Required);
 
-                    var functionalRolePersonResponse = GetOutlookResponseByEmailAsync(meeting, personInFunctionalRole.Email);
-                    personInFunctionalRole.Response = functionalRolePersonResponse;
+                        var functionalRolePersonResponse =
+                            GetOutlookResponseByEmailAsync(meeting, personInFunctionalRole.Email);
+                        personInFunctionalRole.Response = functionalRolePersonResponse;
+                    }
                 }
 
                 if (participant.ExternalEmail != null)

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
@@ -1,41 +1,34 @@
 ﻿using System;
 using System.Collections.Generic;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 
 namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 {
     public class InvitationDto
     {
-        public InvitationDto(MeetingDto meeting) => Meeting = meeting;
-
-        public MeetingDto Meeting { get; }
-    }
-
-    public class MeetingDto
-    {
-        public MeetingDto(
+        public InvitationDto(
+            string projectName,
             string title,
-            string bodyHtml,
+            string description,
             string location,
-            DateTime startTime,
-            DateTime endTime,
-            IEnumerable<ParticipantDto> requiredParticipants,
-            IEnumerable<ParticipantDto> optionalParticipants)
+            DisciplineType type)
         {
+            ProjectName = projectName;
             Title = title;
-            BodyHtml = bodyHtml;
+            Description = description;
             Location = location;
-            StartTimeUtc = startTime;
-            EndTimeUtc = endTime;
-            RequiredParticipants = requiredParticipants;
-            OptionalParticipants = optionalParticipants;
+            Type = type;
         }
 
+        public string ProjectName { get; }
         public string Title { get; }
-        public string BodyHtml { get; }
+        public string Description { get; }
         public string Location { get; }
-        public DateTime StartTimeUtc { get; }
-        public DateTime EndTimeUtc { get; }
-        public IEnumerable<ParticipantDto> RequiredParticipants { get; }
-        public IEnumerable<ParticipantDto> OptionalParticipants { get; }
+        public DisciplineType Type { get; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+        public IEnumerable<ParticipantDto> Participants { get; set; }
+        public IEnumerable<McPkgScopeDto> McPkgScope { get; set; }
+        public IEnumerable<CommPkgScopeDto> CommPkgScope { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
@@ -11,13 +11,15 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             string title,
             string description,
             string location,
-            DisciplineType type)
+            DisciplineType type,
+            string rowVersion)
         {
             ProjectName = projectName;
             Title = title;
             Description = description;
             Location = location;
             Type = type;
+            RowVersion = rowVersion;
         }
 
         public string ProjectName { get; }
@@ -25,6 +27,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public string Description { get; }
         public string Location { get; }
         public DisciplineType Type { get; }
+        public string RowVersion { get; }
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
         public IEnumerable<ParticipantDto> Participants { get; set; }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/McPkgScopeDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/McPkgScopeDto.cs
@@ -1,0 +1,19 @@
+﻿namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
+{
+    public class McPkgScopeDto
+    {
+        public McPkgScopeDto(
+            string mcPkgNo,
+            string description,
+            string commPkgNo)
+        {
+            McPkgNo = mcPkgNo;
+            Description = description;
+            CommPkgNo = commPkgNo;
+        }
+
+        public string McPkgNo { get; }
+        public string Description { get; }
+        public string CommPkgNo { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -1,20 +1,27 @@
-﻿using System;
+﻿using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 
 namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 {
     public class ParticipantDto
     {
-        public ParticipantDto(Guid? oid, string email, string name, MeetingResponse response)
+        public ParticipantDto(
+            Organization organization,
+            int sortKey,
+            string externalEmail,
+            PersonDto person,
+            FunctionalRoleDto functionalRole)
         {
-            Oid = oid;
-            Email = email;
-            Name = name;
-            Response = response;
+            Organization = organization;
+            SortKey = sortKey;
+            ExternalEmail = externalEmail;
+            Person = person;
+            FunctionalRole = functionalRole;
         }
 
-        public Guid? Oid { get; }
-        public MeetingResponse Response { get; }
-        public string Email { get; }
-        public string Name { get; }
+        public Organization Organization { get; }
+        public int SortKey { get; }
+        public string ExternalEmail { get; }
+        public PersonDto Person { get; }
+        public FunctionalRoleDto FunctionalRole { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -7,7 +7,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public ParticipantDto(
             Organization organization,
             int sortKey,
-            string externalEmail,
+            ExternalEmailDto externalEmail,
             PersonDto person,
             FunctionalRoleDto functionalRole)
         {
@@ -20,7 +20,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 
         public Organization Organization { get; }
         public int SortKey { get; }
-        public string ExternalEmail { get; }
+        public ExternalEmailDto ExternalEmail { get; }
         public PersonDto Person { get; }
         public FunctionalRoleDto FunctionalRole { get; }
     }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -9,13 +9,15 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             int sortKey,
             ExternalEmailDto externalEmail,
             PersonDto person,
-            FunctionalRoleDto functionalRole)
+            FunctionalRoleDto functionalRole,
+            string rowVersion)
         {
             Organization = organization;
             SortKey = sortKey;
             ExternalEmail = externalEmail;
             Person = person;
             FunctionalRole = functionalRole;
+            RowVersion = rowVersion;
         }
 
         public Organization Organization { get; }
@@ -23,5 +25,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public ExternalEmailDto ExternalEmail { get; }
         public PersonDto Person { get; }
         public FunctionalRoleDto FunctionalRole { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -9,15 +9,13 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             int sortKey,
             ExternalEmailDto externalEmail,
             PersonDto person,
-            FunctionalRoleDto functionalRole,
-            string rowVersion)
+            FunctionalRoleDto functionalRole)
         {
             Organization = organization;
             SortKey = sortKey;
             ExternalEmail = externalEmail;
             Person = person;
             FunctionalRole = functionalRole;
-            RowVersion = rowVersion;
         }
 
         public Organization Organization { get; }
@@ -25,6 +23,5 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public ExternalEmailDto ExternalEmail { get; }
         public PersonDto Person { get; }
         public FunctionalRoleDto FunctionalRole { get; }
-        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
@@ -23,6 +23,7 @@ namespace Equinor.ProCoSys.IPO.Query
         public string LastName { get; }
         public string AzureOid { get; }
         public string Email { get; }
+        public bool Required { get; set; }
         public OutlookResponse? Response { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
@@ -1,4 +1,6 @@
-﻿namespace Equinor.ProCoSys.IPO.Query
+﻿using Fusion.Integration.Meeting;
+
+namespace Equinor.ProCoSys.IPO.Query
 {
     public class PersonDto
     {
@@ -21,5 +23,6 @@
         public string LastName { get; }
         public string AzureOid { get; }
         public string Email { get; }
+        public OutlookResponse? Response { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
@@ -9,13 +9,15 @@ namespace Equinor.ProCoSys.IPO.Query
             string firstName,
             string lastName,
             string azureOid,
-            string email)
+            string email,
+            string rowVersion)
         {
             Id = id;
             FirstName = firstName;
             LastName = lastName;
             AzureOid = azureOid;
             Email = email;
+            RowVersion = rowVersion;
         }
 
         public int Id { get; }
@@ -25,5 +27,6 @@ namespace Equinor.ProCoSys.IPO.Query
         public string Email { get; }
         public bool Required { get; set; }
         public OutlookResponse? Response { get; set; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/PersonDto.cs
@@ -2,15 +2,24 @@
 {
     public class PersonDto
     {
-        public PersonDto(int id, string firstName, string lastName)
+        public PersonDto(
+            int id,
+            string firstName,
+            string lastName,
+            string azureOid,
+            string email)
         {
             Id = id;
             FirstName = firstName;
             LastName = lastName;
+            AzureOid = azureOid;
+            Email = email;
         }
 
         public int Id { get; }
         public string FirstName { get; }
         public string LastName { get; }
+        public string AzureOid { get; }
+        public string Email { get; }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -119,7 +119,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             await dut.Handle(command, default);
 
             Assert.IsNotNull(_createdInvitation);
-            Assert.AreEqual(2, _saveChangesCount);
+            Assert.AreEqual(1, _saveChangesCount);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandHandlerTests.cs
@@ -25,7 +25,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.DeleteAttachment
         [TestInitialize]
         public void Setup()
         {
-            _invitation = new Invitation(PLANT, "TestProject", "TestInvitation", DisciplineType.DP);
+            _invitation = new Invitation(PLANT, "TestProject", "TestInvitation", "Description", DisciplineType.DP);
             var attachment = new TestableAttachment(PLANT, "ExistingFile.txt");
             attachment.SetId(2);
             _invitation.AddAttachment(attachment);

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -21,6 +21,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private readonly string _plant = "PCS$TEST_PLANT";
         private readonly string _projectName = "Project name";
         private readonly string _title = "Test title";
+        private readonly string _description = "Test description";
         private readonly DisciplineType _type = DisciplineType.DP;
         private Guid _meetingId = new Guid("11111111-2222-2222-2222-333333333333");
         private readonly List<Guid> _requiredParticipantIds = new List<Guid>() { new Guid("22222222-3333-3333-3333-444444444444") };
@@ -65,7 +66,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                     Title = string.Empty
                 })));
 
-            _invitation = new Invitation(_plant, _projectName, _title, _type) { MeetingId = _meetingId };
+            _invitation = new Invitation(_plant, _projectName, _title, _description, _type) { MeetingId = _meetingId };
 
             _invitationRepositoryMock = new Mock<IInvitationRepository>();
             _invitationRepositoryMock
@@ -91,7 +92,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             var dut = new EditInvitationCommandHandler(_invitationRepositoryMock.Object, _meetingClientMock.Object);
 
-            var result = await dut.Handle(command, default);
+            await dut.Handle(command, default);
 
             _meetingClientMock.Verify(x => x.UpdateMeetingAsync(_meetingId, It.IsAny<Action<GeneralMeetingPatcher>>()), Times.Once);
         }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandHandler.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandHandler.cs
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UploadAttachment
         [TestInitialize]
         public void Setup()
         {
-            _invitation = new Invitation(PLANT, "TestProject", "TestInvitation", DisciplineType.DP);
+            _invitation = new Invitation(PLANT, "TestProject", "TestInvitation","Description", DisciplineType.DP);
             _invitation.AddAttachment(new Attachment(PLANT, "ExistingFile.txt"));
             _invitationRepositoryMock = new Mock<IInvitationRepository>();
             _invitationRepositoryMock

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -17,6 +17,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
     {
         private readonly string _projectName = "Project name";
         private readonly string _title = "Test title";
+        private readonly string _description = "Test description";
         private readonly DisciplineType _typeDp = DisciplineType.DP;
 
         private readonly IList<McPkgScopeForCommand> _mcPkgScope = new List<McPkgScopeForCommand>
@@ -54,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var invitation = new Invitation(TestPlant, _projectName, _title, _typeDp);
+                var invitation = new Invitation(TestPlant, _projectName, _title, _description, _typeDp);
                 foreach (var attachment in _attachments)
                 {
                     invitation.AddAttachment(attachment);

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -116,14 +116,20 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
             }
         }
 
-        [TestMethod]
-        public async Task HandleGetRequirementTypeByIdQuery_UnknownId_ShouldReturnNull()
-        {
-            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
-                var result = await dut.Handle(new GetInvitationByIdQuery(246), default);
 
+        [TestMethod]
+        public async Task Handler_ShouldReturnNotFound_IfInvitationIsNotFound()
+        {
+            using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
+            {
+                const int UnknownId = 500;
+                var query = new GetInvitationByIdQuery(UnknownId);
+                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
+
+                var result = await dut.Handle(query, default);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(ResultType.NotFound, result.ResultType);
                 Assert.IsNull(result.Data);
             }
         }
@@ -143,23 +149,6 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
 
                 var invitationDto = result.Data;
                 AssertInvitation(invitationDto, _invitation);
-            }
-        }
-
-        [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfInvitationIsNotFound()
-        {
-            using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
-            {
-                var UnknownId = 500;
-                var query = new GetInvitationByIdQuery(UnknownId);
-                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
-
-                var result = await dut.Handle(query, default);
-
-                Assert.IsNotNull(result);
-                Assert.AreEqual(ResultType.NotFound, result.ResultType);
-                Assert.IsNull(result.Data);
             }
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -102,13 +102,34 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
                                 Location = string.Empty,
                                 Organizer = new ApiPersonDetailsV1(),
                                 OutlookMode = string.Empty,
-                                Participants = new List<ApiMeetingParticipant>(),
+                                Participants = new List<ApiMeetingParticipant>()
+                                {
+                                    new ApiMeetingParticipant()
+                                    {
+                                        Id = Guid.NewGuid(),
+                                        Person = new ApiPersonDetailsV1()
+                                        {
+                                            Id = Guid.NewGuid(),
+                                            Mail = "P1@email.com"
+                                        },
+                                        OutlookResponse = "Required"
+                                    },
+                                    new ApiMeetingParticipant()
+                                    {
+                                        Id = Guid.NewGuid(),
+                                        Person = new ApiPersonDetailsV1()
+                                        {
+                                            Id = Guid.NewGuid(),
+                                            Mail = "FR1@email.com"
+                                        },
+                                        OutlookResponse = "Accepted"
+                                    }
+                                },
                                 Project = null,
                                 ResponsiblePersons = new List<ApiPersonDetailsV1>(),
                                 Series = null,
                                 Title = string.Empty
                             })));
-
 
                 _invitation.SetProtectedIdForTesting(_invitationId);
                 context.Invitations.Add(_invitation);

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -48,7 +48,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
 
                 var PersonParticipant = new Participant(
                     TestPlant,
-                    Organization.Contractor,
+                    Organization.ConstructionCompany,
                     IpoParticipantType.Person,
                     null,
                     "FirstName",

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -137,7 +137,6 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
             }
         }
 
-
         [TestMethod]
         public async Task Handler_ShouldReturnNotFound_IfInvitationIsNotFound()
         {

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -163,6 +163,22 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
             }
         }
 
+        [TestMethod]
+        public async Task Handler_ShouldThrowException_IfMeetingIsNotFound()
+        {
+            using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
+            {
+                _meetingClientMock
+                    .Setup(x => x.GetMeetingAsync(It.IsAny<Guid>(), It.IsAny<Action<ODataQuery>>()))
+                    .Returns(Task.FromResult<GeneralMeeting>(null));
+
+                var query = new GetInvitationByIdQuery(_invitationId);
+                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
+
+                await Assert.ThrowsExceptionAsync<Exception>(() => dut.Handle(query, default));
+            }
+        }
+
         private static void AssertInvitation(InvitationDto invitationDto, Invitation invitation)
         {
             var functionalRoleParticipant = invitation.Participants.First();

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.Infrastructure;
+using Equinor.ProCoSys.IPO.Query.GetInvitationById;
+using Equinor.ProCoSys.IPO.Test.Common;
+using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
+using Fusion.Integration.Http.Models;
+using Fusion.Integration.Meeting;
+using Fusion.Integration.Meeting.Http.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
+{
+    [TestClass]
+    public class GetInvitationByIdQueryHandlerTests : ReadOnlyTestsBase
+    {
+        private Invitation _invitation;
+        private int _invitationId = 246;
+        
+        private Mock<IFusionMeetingClient> _meetingClientMock;
+
+        protected override void SetupNewDatabase(DbContextOptions<IPOContext> dbContextOptions)
+        {
+            using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var MeetingId = new Guid("11111111-2222-2222-2222-333333333333");
+                var PersonAzureOid = new Guid("44444444-5555-5555-5555-666666666666");
+                const string ProjectName = "Project1";
+                const string Description = "Description";
+                const string CommPkgNo = "CommPkgNo";
+
+                var FunctionalRoleParticipant = new Participant(
+                    TestPlant,
+                    Organization.Contractor,
+                    IpoParticipantType.FunctionalRole,
+                    "FR1",
+                    null,
+                    null,
+                    "FR1@email.com",
+                    null,
+                    0);
+
+                var PersonParticipant = new Participant(
+                    TestPlant,
+                    Organization.Contractor,
+                    IpoParticipantType.Person,
+                    null,
+                    "FirstName",
+                    "LastName",
+                    "P1@email.com",
+                    PersonAzureOid,
+                    1);
+
+                var CommPkg = new CommPkg(
+                    TestPlant,
+                    ProjectName,
+                    CommPkgNo,
+                    Description,
+                    "OK");
+
+                var McPkg = new McPkg(
+                    TestPlant,
+                    ProjectName,
+                    CommPkgNo,
+                    "McPkgNo",
+                    Description);
+
+                _invitation = new Invitation(TestPlant, ProjectName, "Title", "Description", DisciplineType.DP)
+                {
+                    MeetingId = MeetingId
+                };
+
+                _invitation.AddParticipant(FunctionalRoleParticipant);
+                _invitation.AddParticipant(PersonParticipant);
+                _invitation.AddCommPkg(CommPkg);
+                _invitation.AddMcPkg(McPkg);
+
+                _meetingClientMock = new Mock<IFusionMeetingClient>();
+                _meetingClientMock
+                    .Setup(x => x.GetMeetingAsync(It.IsAny<Guid>(), It.IsAny<Action<ODataQuery>>()))
+                    .Returns(Task.FromResult(
+                        new GeneralMeeting(
+                            new ApiGeneralMeeting()
+                            {
+                                Classification = string.Empty,
+                                Contract = null,
+                                Convention = string.Empty,
+                                DateCreatedUtc = DateTime.MinValue,
+                                DateEnd = new ApiDateTimeTimeZoneModel(),
+                                DateStart = new ApiDateTimeTimeZoneModel(),
+                                ExternalId = null,
+                                Id = MeetingId,
+                                InviteBodyHtml = string.Empty,
+                                IsDisabled = false,
+                                IsOnlineMeeting = false,
+                                Location = string.Empty,
+                                Organizer = new ApiPersonDetailsV1(),
+                                OutlookMode = string.Empty,
+                                Participants = new List<ApiMeetingParticipant>(),
+                                Project = null,
+                                ResponsiblePersons = new List<ApiPersonDetailsV1>(),
+                                Series = null,
+                                Title = string.Empty
+                            })));
+
+
+                _invitation.SetProtectedIdForTesting(_invitationId);
+                context.Invitations.Add(_invitation);
+                context.SaveChangesAsync().Wait();
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetRequirementTypeByIdQuery_UnknownId_ShouldReturnNull()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
+                var result = await dut.Handle(new GetInvitationByIdQuery(246), default);
+
+                Assert.IsNull(result.Data);
+            }
+        }
+
+        [TestMethod]
+        public async Task Handler_ShouldReturnCorrectInvitation()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var query = new GetInvitationByIdQuery(_invitationId);
+                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
+
+                var result = await dut.Handle(query, default);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(ResultType.Ok, result.ResultType);
+
+                var invitationDto = result.Data;
+                AssertInvitation(invitationDto, _invitation);
+            }
+        }
+
+        [TestMethod]
+        public async Task Handler_ShouldReturnNotFound_IfInvitationIsNotFound()
+        {
+            using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
+            {
+                var UnknownId = 500;
+                var query = new GetInvitationByIdQuery(UnknownId);
+                var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
+
+                var result = await dut.Handle(query, default);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(ResultType.NotFound, result.ResultType);
+                Assert.IsNull(result.Data);
+            }
+        }
+
+        private static void AssertInvitation(InvitationDto invitationDto, Invitation invitation)
+        {
+            var functionalRoleParticipant = invitation.Participants.First();
+            var personParticipant = invitation.Participants.Last();
+            var commPkg = invitation.CommPkgs.First();
+            var mcPkg = invitation.McPkgs.First();
+
+            Assert.AreEqual(invitation.Title, invitationDto.Title);
+            Assert.AreEqual(invitation.Description, invitationDto.Description);
+            Assert.AreEqual(invitation.ProjectName, invitationDto.ProjectName);
+            Assert.AreEqual(invitation.Type, invitationDto.Type);
+            Assert.AreEqual(functionalRoleParticipant.FunctionalRoleCode, invitationDto.Participants.First().FunctionalRole.Code);
+            Assert.AreEqual(personParticipant.AzureOid.ToString(), invitationDto.Participants.Last().Person.AzureOid);
+            Assert.AreEqual(commPkg.CommPkgNo, invitationDto.CommPkgScope.First().CommPkgNo);
+            Assert.AreEqual(mcPkg.McPkgNo, invitationDto.McPkgScope.First().McPkgNo);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryTests.cs
@@ -1,0 +1,17 @@
+﻿using Equinor.ProCoSys.IPO.Query.GetInvitationById;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
+{
+    [TestClass]
+    public class GetInvitationByIdQueryTests
+    {
+        [TestMethod]
+        public void Constructor_SetsProperties()
+        {
+            var dut = new GetInvitationByIdQuery(2);
+
+            Assert.AreEqual(2, dut.Id);
+        }
+    }
+}


### PR DESCRIPTION
DevOps#78040

Get invitation endpoint
Persons which become participants through a functional role (use personal email: yes) are now saved with their respective functional role codes in the db. This is to keep track of which persons are under a functional role and which are not. 