### PR TITLE
78850 - No installations in projects list

### DIFF
--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/MainApiProjectService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/MainApiProjectService.cs
@@ -36,7 +36,8 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Project
         {
             var url = $"{_baseAddress}Projects" +
                       $"?plantId={plant}" +
-                      $"&api-version={_apiVersion}";
+                      $"&api-version={_apiVersion}" +
+                      "&includeInstallations=false";
 
             var projects = await _foreignApiClient.QueryAndDeserializeAsync<List<ProCoSysProject>>(url);
 


### PR DESCRIPTION
Set includeInstallations = false in order to get only projects, not installations, from webapi. 
Not necessary to add any tests for this. 

DevOps#78850 