### PR TITLE
79287 get ipo details by comm pkg no

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQuery.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQuery.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
+{
+    public class GetInvitationsByCommPkgNoQuery : IRequest<Result<List<InvitationForMainDto>>>
+    {
+        public GetInvitationsByCommPkgNoQuery(string commPkgNo, string projectName)
+        {
+            CommPkgNo = commPkgNo;
+            ProjectName = projectName;
+        }
+
+        public string CommPkgNo { get; }
+        public string ProjectName { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Fusion.Integration.Meeting;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
+{
+    public class GetInvitationsByCommPkgNoQueryHandler : IRequestHandler<GetInvitationsByCommPkgNoQuery, Result<List<InvitationForMainDto>>>
+    {
+        private readonly IReadOnlyContext _context;
+        private readonly IFusionMeetingClient _meetingClient;
+
+        public GetInvitationsByCommPkgNoQueryHandler(
+            IReadOnlyContext context,
+            IFusionMeetingClient meetingClient)
+        {
+            _context = context;
+            _meetingClient = meetingClient;
+        }
+
+        public async Task<Result<List<InvitationForMainDto>>> Handle(GetInvitationsByCommPkgNoQuery request,
+            CancellationToken token)
+        {
+            var invitations = await
+                (from invitation in _context.QuerySet<Invitation>()
+                    .Include(i => i.CommPkgs)
+                    .Include(i => i.McPkgs)
+                    .Where(i => i.ProjectName == request.ProjectName 
+                                && (i.McPkgs.Any(mcPkg => mcPkg.CommPkgNo == request.CommPkgNo)
+                                || i.CommPkgs.Any(commPkg => commPkg.CommPkgNo == request.CommPkgNo)))
+                 select invitation).ToListAsync(token);
+
+
+            var invitationForMainDtos = new List<InvitationForMainDto>();
+
+            foreach (var invitation in invitations)
+            {
+                var meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId, query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
+                if (meeting == null)
+                {
+                    throw new Exception($"Could not get meeting with id {invitation.MeetingId} from Fusion");
+                }
+
+                var invitationForMainDto = ConvertToInvitationForMainDto(invitation, meeting);
+
+                invitationForMainDtos.Add(invitationForMainDto);
+            }
+
+            return new SuccessResult<List<InvitationForMainDto>>(invitationForMainDtos);
+        }
+
+        private static InvitationForMainDto ConvertToInvitationForMainDto(Invitation invitation, GeneralMeeting meeting)
+        {
+            var invitationForMainDto = new InvitationForMainDto(
+                    invitation.Id,
+                    invitation.Title,
+                    invitation.Description,
+                    invitation.Type,
+                    invitation.Status,
+                    invitation.RowVersion.ConvertToString())
+            {
+                MeetingTimeUtc = meeting.StartDate.DatetimeUtc
+            };
+
+            return invitationForMainDto;
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandler.cs
@@ -37,7 +37,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
                                 || i.CommPkgs.Any(commPkg => commPkg.CommPkgNo == request.CommPkgNo)))
                  select invitation).ToListAsync(token);
 
-
             var invitationForMainDtos = new List<InvitationForMainDto>();
 
             foreach (var invitation in invitations)

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/InvitationForMainDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/InvitationForMainDto.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+
+namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
+{
+    public class InvitationForMainDto
+    {
+        public InvitationForMainDto(
+            int id,
+            string title,
+            string description,
+            DisciplineType type,
+            IpoStatus status,
+            string rowVersion)
+        {
+            Id = id;
+            Title = title;
+            Description = description;
+            Type = type;
+            Status = status;
+            RowVersion = rowVersion;
+        }
+
+        public int Id { get; }
+        public string Title { get; }
+        public string Description { get; }
+        public DisciplineType Type { get; }
+        public IpoStatus Status { get; }
+        public string RowVersion { get; }
+        public DateTime MeetingTimeUtc { get; set; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
@@ -41,7 +41,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
             return this.FromResult(result);
         }
 
-        [Authorize(Roles = Permissions.IPO_READ)]
+        [Authorize(Roles = Permissions.COMMPKG_READ)]
         [HttpGet("/ByCommPkgNo/{commPkgNo}")]
         public async Task<ActionResult<InvitationForMainDto>> GetInvitationsByCommPkgNo(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
@@ -11,6 +11,7 @@ using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Query.GetAttachmentById;
 using Equinor.ProCoSys.IPO.Query.GetAttachments;
 using Equinor.ProCoSys.IPO.Query.GetInvitationById;
+using Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo;
 using Equinor.ProCoSys.IPO.WebApi.Middleware;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -37,6 +38,20 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
             [FromRoute] int id)
         {
             var result = await _mediator.Send(new GetInvitationByIdQuery(id));
+            return this.FromResult(result);
+        }
+
+        [Authorize(Roles = Permissions.IPO_READ)]
+        [HttpGet("/ByCommPkgNo/{commPkgNo}")]
+        public async Task<ActionResult<InvitationForMainDto>> GetInvitationsByCommPkgNo(
+            [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string plant,
+            [FromRoute] string commPkgNo,
+            [FromQuery] string projectName)
+        {
+            var result = await _mediator.Send(new GetInvitationsByCommPkgNoQuery(commPkgNo, projectName));
             return this.FromResult(result);
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.Infrastructure;
+using Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo;
+using Equinor.ProCoSys.IPO.Test.Common;
+using Fusion.Integration.Http.Models;
+using Fusion.Integration.Meeting;
+using Fusion.Integration.Meeting.Http.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
+{
+    [TestClass]
+    public class GetInvitationsByCommPkgNoQueryHandlerTests : ReadOnlyTestsBase
+    {
+        private Invitation _dpInvitation;
+        private Invitation _mdpInvitation;
+        private int _dpInvitationId;
+        private int _mdpInvitationId;
+        private const string _commPkgNo = "CommPkgNo";
+        private const string _projectName = "Project1";
+
+        private Mock<IFusionMeetingClient> _meetingClientMock;
+
+        protected override void SetupNewDatabase(DbContextOptions<IPOContext> dbContextOptions)
+        {
+            using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var MeetingId = new Guid("11111111-2222-2222-2222-333333333333");
+                var PersonAzureOid = new Guid("44444444-5555-5555-5555-666666666666");
+                const string Description = "Description";
+
+                var FunctionalRoleParticipant = new Participant(
+                    TestPlant,
+                    Organization.Contractor,
+                    IpoParticipantType.FunctionalRole,
+                    "FR1",
+                    null,
+                    null,
+                    "FR1@email.com",
+                    null,
+                    0);
+
+                var PersonParticipant = new Participant(
+                    TestPlant,
+                    Organization.ConstructionCompany,
+                    IpoParticipantType.Person,
+                    null,
+                    "FirstName",
+                    "LastName",
+                    "P1@email.com",
+                    PersonAzureOid,
+                    1);
+
+                var CommPkg = new CommPkg(
+                    TestPlant,
+                    _projectName,
+                    _commPkgNo,
+                    Description,
+                    "OK");
+
+                var McPkg = new McPkg(
+                    TestPlant,
+                    _projectName,
+                    _commPkgNo,
+                    "McPkgNo",
+                    Description);
+
+                _dpInvitation = new Invitation(TestPlant, _projectName, "DP Title", "Description1", DisciplineType.DP)
+                {
+                    MeetingId = MeetingId
+                };
+
+                _dpInvitation.AddParticipant(FunctionalRoleParticipant);
+                _dpInvitation.AddParticipant(PersonParticipant);
+                _dpInvitation.AddMcPkg(McPkg);
+
+                _mdpInvitation = new Invitation(TestPlant, _projectName, "MDP Title", "Description2", DisciplineType.MDP)
+                {
+                    MeetingId = MeetingId
+                };
+
+                _mdpInvitation.AddParticipant(FunctionalRoleParticipant);
+                _mdpInvitation.AddParticipant(PersonParticipant);
+                _mdpInvitation.AddCommPkg(CommPkg);
+
+                _meetingClientMock = new Mock<IFusionMeetingClient>();
+                _meetingClientMock
+                    .Setup(x => x.GetMeetingAsync(It.IsAny<Guid>(), It.IsAny<Action<ODataQuery>>()))
+                    .Returns(Task.FromResult(
+                        new GeneralMeeting(
+                            new ApiGeneralMeeting()
+                            {
+                                Classification = string.Empty,
+                                Contract = null,
+                                Convention = string.Empty,
+                                DateCreatedUtc = DateTime.MinValue,
+                                DateEnd = new ApiDateTimeTimeZoneModel(),
+                                DateStart = new ApiDateTimeTimeZoneModel(),
+                                ExternalId = null,
+                                Id = MeetingId,
+                                InviteBodyHtml = string.Empty,
+                                IsDisabled = false,
+                                IsOnlineMeeting = false,
+                                Location = string.Empty,
+                                Organizer = new ApiPersonDetailsV1(),
+                                OutlookMode = string.Empty,
+                                Participants = new List<ApiMeetingParticipant>()
+                                {
+                                    new ApiMeetingParticipant()
+                                    {
+                                        Id = Guid.NewGuid(),
+                                        Person = new ApiPersonDetailsV1()
+                                        {
+                                            Id = Guid.NewGuid(),
+                                            Mail = "P1@email.com"
+                                        },
+                                        OutlookResponse = "Required"
+                                    },
+                                    new ApiMeetingParticipant()
+                                    {
+                                        Id = Guid.NewGuid(),
+                                        Person = new ApiPersonDetailsV1()
+                                        {
+                                            Id = Guid.NewGuid(),
+                                            Mail = "FR1@email.com"
+                                        },
+                                        OutlookResponse = "Accepted"
+                                    }
+                                },
+                                Project = null,
+                                ResponsiblePersons = new List<ApiPersonDetailsV1>(),
+                                Series = null,
+                                Title = string.Empty
+                            })));
+
+                context.Invitations.Add(_dpInvitation);
+                context.Invitations.Add(_mdpInvitation);
+                context.SaveChangesAsync().Wait();
+                _dpInvitationId = _dpInvitation.Id;
+                _mdpInvitationId = _mdpInvitation.Id;
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetInvitationsByCommPkgNoQuery_ShouldReturnOkResult()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var query = new GetInvitationsByCommPkgNoQuery(_commPkgNo, _projectName);
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+                var result = await dut.Handle(query, default);
+
+                Assert.AreEqual(ResultType.Ok, result.ResultType);
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetInvitationsByCommPkgNoQuery_ShouldReturnCorrectInvitations()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var query = new GetInvitationsByCommPkgNoQuery(_commPkgNo, _projectName);
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+
+                var result = await dut.Handle(query, default);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(ResultType.Ok, result.ResultType);
+
+                var invitationDtos = result.Data;
+                Assert.AreEqual(2, invitationDtos.Count);
+
+                AssertInvitation(invitationDtos.Single(i => i.Id == _dpInvitationId), _dpInvitation);
+                AssertInvitation(invitationDtos.Single(i => i.Id == _mdpInvitationId), _mdpInvitation);
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetInvitationsByCommPkgNoQuery_ShouldThrowException_IfMeetingIsNotFound()
+        {
+            using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
+            {
+                _meetingClientMock
+                    .Setup(x => x.GetMeetingAsync(It.IsAny<Guid>(), It.IsAny<Action<ODataQuery>>()))
+                    .Returns(Task.FromResult<GeneralMeeting>(null));
+
+                var query = new GetInvitationsByCommPkgNoQuery(_commPkgNo, _projectName);
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+
+                await Assert.ThrowsExceptionAsync<Exception>(() => dut.Handle(query, default));
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetInvitationsByCommPkgNoQuery_ShouldReturnEmptyListOfInvitations_IfNoInvitationsFound()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+
+                var result = await dut.Handle(new GetInvitationsByCommPkgNoQuery("Unknown", _projectName), default);
+                Assert.AreEqual(0, result.Data.Count);
+            }
+        }
+
+        private static void AssertInvitation(InvitationForMainDto invitationDto, Invitation invitation)
+        {
+            Assert.AreEqual(invitation.Title, invitationDto.Title);
+            Assert.AreEqual(invitation.Description, invitationDto.Description);
+            Assert.AreEqual(invitation.Type, invitationDto.Type);
+            Assert.AreEqual(invitation.Status, invitationDto.Status);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
@@ -65,11 +65,18 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
                     Description,
                     "OK");
 
-                var McPkg = new McPkg(
+                var McPkg1 = new McPkg(
                     TestPlant,
                     _projectName,
                     _commPkgNo,
-                    "McPkgNo",
+                    "McPkgNo1",
+                    Description);
+
+                var McPkg2 = new McPkg(
+                    TestPlant,
+                    _projectName,
+                    _commPkgNo,
+                    "McPkgNo2",
                     Description);
 
                 _dpInvitation = new Invitation(TestPlant, _projectName, "DP Title", "Description1", DisciplineType.DP)
@@ -79,7 +86,8 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
 
                 _dpInvitation.AddParticipant(FunctionalRoleParticipant);
                 _dpInvitation.AddParticipant(PersonParticipant);
-                _dpInvitation.AddMcPkg(McPkg);
+                _dpInvitation.AddMcPkg(McPkg1);
+                _dpInvitation.AddMcPkg(McPkg2);
 
                 _mdpInvitation = new Invitation(TestPlant, _projectName, "MDP Title", "Description2", DisciplineType.MDP)
                 {

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryTests.cs
@@ -1,0 +1,18 @@
+﻿using Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
+{
+    [TestClass]
+    public class GetInvitationsByCommPkgNoQueryTests
+    {
+        [TestMethod]
+        public void Constructor_SetsProperties()
+        {
+            var dut = new GetInvitationsByCommPkgNoQuery("CommPkgNo", "ProjectName");
+
+            Assert.AreEqual("CommPkgNo", dut.CommPkgNo);
+            Assert.AreEqual("ProjectName", dut.ProjectName);
+        }
+    }
+}


### PR DESCRIPTION
DevOps#79287
gets invitations by commpkgno (all invitations with given commpkg as scope, or any mcpkg under it). 
currently returns id, title, description, type, status and rowversion. 

Missing M01 & M02 stuff, we need to discuss how to handle this.