### PR TITLE
80104 workaround for if user is not directly invited to fusion meeting

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -58,7 +58,15 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         {
             var transaction = await _unitOfWork.BeginTransaction(cancellationToken);
             var participants = new List<BuilderParticipant>();
-            var invitation = new Invitation(_plantProvider.Plant, request.ProjectName, request.Title, request.Description, request.Type);
+            var invitation = new Invitation(
+                _plantProvider.Plant,
+                request.ProjectName,
+                request.Title,
+                request.Description,
+                request.Type,
+                request.StartTime,
+                request.EndTime,
+                request.Location);
             _invitationRepository.Add(invitation);
 
             if (request.CommPkgScope.Count > 0)

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -62,6 +62,9 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
             invitation.Title = request.Title;
             invitation.Description = request.Description;
             invitation.Type = request.Type;
+            invitation.StartTimeUtc = request.StartTime;
+            invitation.EndTimeUtc = request.EndTime;
+            invitation.Location = request.Location;
 
             UpdateMcPkgScope(invitation, request.UpdatedMcPkgScope, invitation.ProjectName);
             UpdateCommPkgScope(invitation, request.UpdatedCommPkgScope, invitation.ProjectName);

--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
@@ -24,7 +24,15 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
         {
         }
 
-        public Invitation(string plant, string projectName, string title, string description, DisciplineType type)
+        public Invitation(
+            string plant,
+            string projectName,
+            string title,
+            string description,
+            DisciplineType type,
+            DateTime startTimeUtc,
+            DateTime endTimeUtc,
+            string location)
             : base(plant)
         {
             if (string.IsNullOrEmpty(projectName))
@@ -42,11 +50,17 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
             Description = description;
             Type = type;
             Status = IpoStatus.Planned;
+            StartTimeUtc = startTimeUtc;
+            EndTimeUtc = endTimeUtc;
+            Location = location;
         }
         public string ProjectName { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
         public DisciplineType Type { get; set; }
+        public DateTime StartTimeUtc { get; set; }
+        public DateTime EndTimeUtc { get; set; }
+        public string Location { get; set; }
         public IReadOnlyCollection<McPkg> McPkgs => _mcPkgs.AsReadOnly();
         public IReadOnlyCollection<CommPkg> CommPkgs => _commPkgs.AsReadOnly();
         public IReadOnlyCollection<Participant> Participants => _participants.AsReadOnly();

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201216114423_DateTimeAndLocationColumnsOnInvitation.Designer.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201216114423_DateTimeAndLocationColumnsOnInvitation.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.ProCoSys.IPO.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
 {
     [DbContext(typeof(IPOContext))]
-    partial class IPOContextModelSnapshot : ModelSnapshot
+    [Migration("20201216114423_DateTimeAndLocationColumnsOnInvitation")]
+    partial class DateTimeAndLocationColumnsOnInvitation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201216114423_DateTimeAndLocationColumnsOnInvitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20201216114423_DateTimeAndLocationColumnsOnInvitation.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
+{
+    public partial class DateTimeAndLocationColumnsOnInvitation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "EndTimeUtc",
+                table: "Invitations",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Location",
+                table: "Invitations",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StartTimeUtc",
+                table: "Invitations",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EndTimeUtc",
+                table: "Invitations");
+
+            migrationBuilder.DropColumn(
+                name: "Location",
+                table: "Invitations");
+
+            migrationBuilder.DropColumn(
+                name: "StartTimeUtc",
+                table: "Invitations");
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -41,15 +41,25 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
 
             if (createdBy == null)
             {
-                throw new Exception($"Could not get person that created the IPO with id {invitation.CreatedById}");
+                return new NotFoundResult<InvitationDto>($"Could not get person that created the IPO with id {invitation.CreatedById}");
             }
 
             var createdByName = createdBy.FirstName + ' ' + createdBy.LastName;
 
-            var meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId, query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
-            if (meeting == null)
+            GeneralMeeting meeting;
+            try
             {
-                throw new Exception($"Could not get meeting with id {invitation.MeetingId} from Fusion");
+                meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId,
+                    query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
+
+                if (meeting == null)
+                {
+                    return new NotFoundResult<InvitationDto>($"Could not get meeting with id {invitation.MeetingId} from Fusion");
+                }
+            }
+            catch (Exception e)
+            {
+                meeting = null; //user has not been invited to IPO with their personal email
             }
 
             var invitationDto = ConvertToInvitationDto(invitation, createdByName, meeting);
@@ -63,14 +73,14 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 invitation.ProjectName,
                 invitation.Title,
                 invitation.Description,
-                meeting.Location,
+                invitation.Location,
                 invitation.Type,
                 invitation.Status,
                 createdBy,
+                invitation.StartTimeUtc,
+                invitation.EndTimeUtc,
                 invitation.RowVersion.ConvertToString())
             {
-                StartTimeUtc = meeting.StartDate.DatetimeUtc,
-                EndTimeUtc = meeting.EndDate.DatetimeUtc,
                 Participants = ConvertToParticipantDto(invitation.Participants),
                 McPkgScope = ConvertToMcPkgDto(invitation.McPkgs),
                 CommPkgScope = ConvertToCommPkgDto(invitation.CommPkgs)
@@ -87,7 +97,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             {
                 if (participant.Person != null)
                 {
-                    var participantPersonResponse = GetOutlookResponseByEmailAsync(meeting, participant.Person?.Person?.Email);
+                    var participantPersonResponse = meeting != null
+                        ? GetOutlookResponseByEmailAsync(meeting, participant.Person?.Person?.Email)
+                        : null;
                     participant.Person.Response = participantPersonResponse;
                 }
 
@@ -95,24 +107,31 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 {
                     foreach (var personInFunctionalRole in participant.FunctionalRole?.Persons)
                     {
-                        var participantType = GetParticipantTypeByEmail(meeting, personInFunctionalRole.Person.Email);
+                        var participantType = meeting != null
+                            ? GetParticipantTypeByEmail(meeting, personInFunctionalRole.Person.Email)
+                            : null;
                         personInFunctionalRole.Required = participantType.Equals(ParticipantType.Required);
 
-                        var functionalRolePersonResponse =
-                            GetOutlookResponseByEmailAsync(meeting, personInFunctionalRole.Person.Email);
+                        var functionalRolePersonResponse = meeting != null
+                            ? GetOutlookResponseByEmailAsync(meeting, personInFunctionalRole.Person.Email)
+                            : null;
                         personInFunctionalRole.Response = functionalRolePersonResponse;
                     }
                 }
 
                 if (participant.ExternalEmail != null)
                 {
-                   var externalEmailResponse = GetOutlookResponseByEmailAsync(meeting, participant.ExternalEmail?.ExternalEmail);
+                    var externalEmailResponse = meeting != null
+                        ? GetOutlookResponseByEmailAsync(meeting, participant.ExternalEmail?.ExternalEmail)
+                        : null;
                     participant.ExternalEmail.Response = externalEmailResponse;
                 }
 
                 if (participant.FunctionalRole?.Email != null)
                 {
-                    var functionalRoleResponse = GetOutlookResponseByEmailAsync(meeting, participant.FunctionalRole.Email);
+                    var functionalRoleResponse = meeting != null
+                        ? GetOutlookResponseByEmailAsync(meeting, participant.FunctionalRole.Email)
+                        : null;
                     participant.FunctionalRole.Response = functionalRoleResponse;
                 }
             }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -51,11 +51,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             {
                 meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId,
                     query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
-
-                if (meeting == null)
-                {
-                    return new NotFoundResult<InvitationDto>($"Could not get meeting with id {invitation.MeetingId} from Fusion");
-                }
             }
             catch (Exception e)
             {

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
@@ -14,6 +14,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             DisciplineType type,
             IpoStatus status,
             string createdBy,
+            DateTime startTimeUtc,
+            DateTime endTimeUtc,
             string rowVersion)
         {
             ProjectName = projectName;
@@ -23,6 +25,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             Type = type;
             Status = status;
             CreatedBy = createdBy;
+            StartTimeUtc = startTimeUtc;
+            EndTimeUtc = endTimeUtc;
             RowVersion = rowVersion;
         }
 
@@ -33,9 +37,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public DisciplineType Type { get; }
         public IpoStatus Status { get; }
         public string CreatedBy { get; }
+        public DateTime StartTimeUtc { get; }
+        public DateTime EndTimeUtc { get; }
         public string RowVersion { get; }
-        public DateTime StartTimeUtc { get; set; }
-        public DateTime EndTimeUtc { get; set; }
         public IEnumerable<ParticipantDto> Participants { get; set; }
         public IEnumerable<McPkgScopeDto> McPkgScope { get; set; }
         public IEnumerable<CommPkgScopeDto> CommPkgScope { get; set; }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandler.cs
@@ -15,15 +15,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
     public class GetInvitationsByCommPkgNoQueryHandler : IRequestHandler<GetInvitationsByCommPkgNoQuery, Result<List<InvitationForMainDto>>>
     {
         private readonly IReadOnlyContext _context;
-        private readonly IFusionMeetingClient _meetingClient;
 
-        public GetInvitationsByCommPkgNoQueryHandler(
-            IReadOnlyContext context,
-            IFusionMeetingClient meetingClient)
-        {
-            _context = context;
-            _meetingClient = meetingClient;
-        }
+        public GetInvitationsByCommPkgNoQueryHandler(IReadOnlyContext context) 
+            => _context = context;
 
         public async Task<Result<List<InvitationForMainDto>>> Handle(GetInvitationsByCommPkgNoQuery request,
             CancellationToken token)
@@ -41,34 +35,21 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
 
             foreach (var invitation in invitations)
             {
-                var meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId, query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
-                if (meeting == null)
-                {
-                    throw new Exception($"Could not get meeting with id {invitation.MeetingId} from Fusion");
-                }
-
-                var invitationForMainDto = ConvertToInvitationForMainDto(invitation, meeting);
-
+                var invitationForMainDto = ConvertToInvitationForMainDto(invitation);
                 invitationForMainDtos.Add(invitationForMainDto);
             }
 
             return new SuccessResult<List<InvitationForMainDto>>(invitationForMainDtos);
         }
 
-        private static InvitationForMainDto ConvertToInvitationForMainDto(Invitation invitation, GeneralMeeting meeting)
-        {
-            var invitationForMainDto = new InvitationForMainDto(
-                    invitation.Id,
-                    invitation.Title,
-                    invitation.Description,
-                    invitation.Type,
-                    invitation.Status,
-                    invitation.RowVersion.ConvertToString())
-            {
-                MeetingTimeUtc = meeting.StartDate.DatetimeUtc
-            };
-
-            return invitationForMainDto;
-        }
+        private static InvitationForMainDto ConvertToInvitationForMainDto(Invitation invitation) 
+            => new InvitationForMainDto(
+                invitation.Id,
+                invitation.Title,
+                invitation.Description,
+                invitation.Type,
+                invitation.Status,
+                invitation.StartTimeUtc,
+                invitation.RowVersion.ConvertToString());
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/InvitationForMainDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsByCommPkgNo/InvitationForMainDto.cs
@@ -11,6 +11,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
             string description,
             DisciplineType type,
             IpoStatus status,
+            DateTime meetingTimeUtc,
             string rowVersion)
         {
             Id = id;
@@ -18,6 +19,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
             Description = description;
             Type = type;
             Status = status;
+            MeetingTimeUtc = meetingTimeUtc;
             RowVersion = rowVersion;
         }
 
@@ -26,7 +28,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo
         public string Description { get; }
         public DisciplineType Type { get; }
         public IpoStatus Status { get; }
+        public DateTime MeetingTimeUtc { get; }
         public string RowVersion { get; }
-        public DateTime MeetingTimeUtc { get; set; }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
@@ -108,7 +108,16 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
                 .Returns(Task.FromResult(personDetails));
 
             //create invitation
-            _invitation = new Invitation(_plant, _projectName, _title, _description, _type) { MeetingId = _meetingId };
+            _invitation = new Invitation(
+                    _plant,
+                    _projectName,
+                    _title,
+                    _description,
+                    _type,
+                    new DateTime(),
+                    new DateTime(),
+                    null)
+                { MeetingId = _meetingId };
             var participant1 = new Participant(
                 _plant,
                 _participants[0].Organization,

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
@@ -110,7 +110,16 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
                 .Returns(Task.FromResult(personDetails));
 
             //create invitation
-            _invitation = new Invitation(_plant, _projectName, _title, _description, _type) { MeetingId = _meetingId };
+            _invitation = new Invitation(
+                    _plant,
+                    _projectName,
+                    _title,
+                    _description,
+                    _type,
+                    new DateTime(),
+                    new DateTime(),
+                    null)
+                { MeetingId = _meetingId };
             var participant1 = new Participant(
                 _plant,
                 _participants[0].Organization,

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.BlobStorage;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.DeleteAttachment;
 using Equinor.ProCoSys.IPO.Domain;
@@ -25,7 +26,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.DeleteAttachment
         [TestInitialize]
         public void Setup()
         {
-            _invitation = new Invitation(PLANT, "TestProject", "TestInvitation", "Description", DisciplineType.DP);
+            _invitation = new Invitation(
+                PLANT,
+                "TestProject",
+                "TestInvitation", 
+                "Description",
+                DisciplineType.DP,
+                new DateTime(),
+                new DateTime(),
+                null);
             var attachment = new TestableAttachment(PLANT, "ExistingFile.txt");
             attachment.SetId(2);
             _invitation.AddAttachment(attachment);

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -213,7 +213,16 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 .Returns(Task.FromResult(newPcsFrDetails));
 
             //create invitation
-            _invitation = new Invitation(_plant, _projectName, _title, _description, _type) { MeetingId = _meetingId };
+            _invitation = new Invitation(
+                    _plant,
+                    _projectName,
+                    _title,
+                    _description,
+                    _type,
+                    new DateTime(),
+                    new DateTime(),
+                    null) 
+                { MeetingId = _meetingId };
             _invitation.AddMcPkg(new McPkg(_plant, _projectName, _commPkgNo, _mcPkgNo1, "d"));
             _invitation.AddMcPkg(new McPkg(_plant, _projectName, _commPkgNo, _mcPkgNo2, "d2"));
             var participant = new Participant(

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandHandlerTests.cs
@@ -71,7 +71,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
                 .Returns(Task.FromResult(personDetails));
 
             //create invitation
-            _invitation = new Invitation(_plant, _projectName, _title, _description, _type) { MeetingId = _meetingId };
+            _invitation = new Invitation(
+                _plant,
+                _projectName,
+                _title,
+                _description,
+                _type,
+                new DateTime(),
+                new DateTime(),
+                null) { MeetingId = _meetingId };
             var participant = new Participant(
                 _plant,
                 Organization.Operation,

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
@@ -90,7 +90,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
                 .Returns(Task.FromResult(personDetails));
 
             //create invitation
-            _invitation = new Invitation(_plant, _projectName, _title, _description, _type) { MeetingId = _meetingId };
+            _invitation = new Invitation(
+                _plant,
+                _projectName,
+                _title,
+                _description,
+                _type,
+                new DateTime(),
+                new DateTime(),
+                null) { MeetingId = _meetingId };
 
             var participant1 = new Participant(
                 _plant,

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandHandler.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.BlobStorage;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UploadAttachment;
@@ -27,7 +28,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UploadAttachment
         [TestInitialize]
         public void Setup()
         {
-            _invitation = new Invitation(PLANT, "TestProject", "TestInvitation","Description", DisciplineType.DP);
+            _invitation = new Invitation(
+                PLANT,
+                "TestProject",
+                "TestInvitation",
+                "Description",
+                DisciplineType.DP,
+                new DateTime(),
+                new DateTime(),
+                null);
             _invitation.AddAttachment(new Attachment(PLANT, "ExistingFile.txt"));
             _invitationRepositoryMock = new Mock<IInvitationRepository>();
             _invitationRepositoryMock

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -68,7 +68,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var invitationWithCurrentUserAsParticipants = new Invitation(TestPlant, _projectName, _title1, _description, _typeDp);
+                var invitationWithCurrentUserAsParticipants = new Invitation(
+                    TestPlant,
+                    _projectName,
+                    _title1,
+                    _description,
+                    _typeDp,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
                 foreach (var attachment in _attachments)
                 {
                     invitationWithCurrentUserAsParticipants.AddAttachment(attachment);
@@ -111,7 +119,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 invitationWithCurrentUserAsParticipants.AddParticipant(participant2);
                 invitationWithCurrentUserAsParticipants.AddParticipant(participant3);
 
-                var invitationWithFrAsParticipants = new Invitation(TestPlant, _projectName, _title2, _description, _typeDp);
+                var invitationWithFrAsParticipants = new Invitation(
+                    TestPlant,
+                    _projectName,
+                    _title2,
+                    _description,
+                    _typeDp,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
                 context.Invitations.Add(invitationWithFrAsParticipants);
                 _invitationIdWithFrAsParticipants = invitationWithFrAsParticipants.Id;
                 var frContractor = new Participant(
@@ -151,11 +167,27 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 invitationWithFrAsParticipants.AddParticipant(frConstructionCompany);
                 invitationWithFrAsParticipants.AddParticipant(frOperation);
 
-                var invitationWithoutParticipants = new Invitation(TestPlant, _projectName2, _title3, _description, _typeDp);
+                var invitationWithoutParticipants = new Invitation(
+                    TestPlant,
+                    _projectName2,
+                    _title3,
+                    _description,
+                    _typeDp,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
                 context.Invitations.Add(invitationWithoutParticipants);
                 _invitationIdWithoutParticipants = invitationWithoutParticipants.Id;
 
-                var invitationWithNotCurrentUserAsParticipants = new Invitation(TestPlant, _projectName2, _title4, _description, _typeDp);
+                var invitationWithNotCurrentUserAsParticipants = new Invitation(
+                    TestPlant,
+                    _projectName2,
+                    _title4,
+                    _description,
+                    _typeDp,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
                 context.Invitations.Add(invitationWithNotCurrentUserAsParticipants);
                 _invitationIdWithNotCurrentUserOidAsParticipants = invitationWithNotCurrentUserAsParticipants.Id;
                 var contractorParticipant = new Participant(

--- a/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
@@ -31,8 +31,24 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
         [TestInitialize]
         public void Setup()
         {
-            _dutWithMcPkgScope = new Invitation(TestPlant, ProjectName, Title, Description, DisciplineType.MDP);
-            _dutWithCommPkgScope = new Invitation(TestPlant, ProjectName, Title2, Description, DisciplineType.MDP);
+            _dutWithMcPkgScope = new Invitation(
+                TestPlant,
+                ProjectName,
+                Title,
+                Description,
+                DisciplineType.MDP,
+                new DateTime(),
+                new DateTime(),
+                null);
+            _dutWithCommPkgScope = new Invitation(
+                TestPlant,
+                ProjectName,
+                Title2,
+                Description,
+                DisciplineType.MDP,
+                new DateTime(),
+                new DateTime(),
+                null);
             _personParticipantId = 10033;
             _functionalRoleParticipantId = 3;
             _externalParticipantId = 967;
@@ -102,13 +118,29 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
         [TestMethod]
         public void Constructor_ShouldThrowException_WhenTitleNotGiven() =>
             Assert.ThrowsException<ArgumentNullException>(() =>
-                new Invitation(TestPlant, ProjectName, null, Description, DisciplineType.MDP)
+                new Invitation(
+                    TestPlant,
+                    ProjectName,
+                    null,
+                    Description,
+                    DisciplineType.MDP,
+                    new DateTime(),
+                    new DateTime(),
+                    null)
             );
 
         [TestMethod]
         public void Constructor_ShouldThrowException_WhenProjectNameNotGiven() =>
             Assert.ThrowsException<ArgumentNullException>(() =>
-                new Invitation(TestPlant, null, Title, Description, DisciplineType.MDP)
+                new Invitation(
+                    TestPlant,
+                    null,
+                    Title,
+                    Description,
+                    DisciplineType.MDP,
+                    new DateTime(),
+                    new DateTime(),
+                    null)
             );
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Infrastructure.Tests/Repositories/InvitationRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Infrastructure.Tests/Repositories/InvitationRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
@@ -56,9 +57,25 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Tests.Repositories
                 0);
             _participant.SetProtectedIdForTesting(ParticipantId);
 
-            _invitationWithMcPkg = new Invitation(TestPlant, "ProjectName", "Title", "D", DisciplineType.DP);
+            _invitationWithMcPkg = new Invitation(
+                TestPlant,
+                "ProjectName",
+                "Title",
+                "D",
+                DisciplineType.DP,
+                new DateTime(),
+                new DateTime(),
+                null);
             _invitationWithMcPkg.SetProtectedIdForTesting(InvitationWithMcPkgId);
-            _invitationWithCommPkg = new Invitation(TestPlant, "ProjectName", "Title 2", "D", DisciplineType.DP);
+            _invitationWithCommPkg = new Invitation(
+                TestPlant,
+                "ProjectName",
+                "Title 2",
+                "D",
+                DisciplineType.DP,
+                new DateTime(),
+                new DateTime(),
+                null);
 
             _invitationWithMcPkg.AddMcPkg(_mcPkg);
             _invitationWithMcPkg.AddParticipant(_participant);

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetAttachmentById/GetAttachmentByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetAttachmentById/GetAttachmentByIdQueryHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.BlobStorage;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Infrastructure;
@@ -21,7 +22,9 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetAttachmentById
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var invitation = new Invitation(TestPlant, "TestProject", "TestInvitation", "TestDescriptioN", DisciplineType.DP);
+                var invitation = new Invitation(TestPlant, "TestProject", "TestInvitation", "TestDescriptioN", DisciplineType.DP, new DateTime(),
+                    new DateTime(),
+                    null);
                 var attachmentA = new Attachment(TestPlant, "fileA.txt");
                 var attachmentB = new Attachment(TestPlant, "fileB.txt");
                 invitation.AddAttachment(attachmentA);

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetAttachments/GetAttachmentsQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetAttachments/GetAttachmentsQueryHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.BlobStorage;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Infrastructure;
@@ -22,7 +23,15 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetAttachments
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var invitation = new Invitation(TestPlant, "TestProject", "TestInvitation", "TestDescriptioN", DisciplineType.DP);
+                var invitation = new Invitation(
+                    TestPlant,
+                    "TestProject",
+                    "TestInvitation",
+                    "TestDescription",
+                    DisciplineType.DP,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
                 var attachmentA = new Attachment(TestPlant, "fileA.txt");
                 var attachmentB = new Attachment(TestPlant, "fileB.txt");
                 invitation.AddAttachment(attachmentA);

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -182,7 +182,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
         }
 
         [TestMethod]
-        public async Task Handler_ShouldThrowException_IfMeetingIsNotFound()
+        public async Task Handler_ShouldRetrunIpo_IfMeetingIsNotFound()
         {
             using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
             {
@@ -194,8 +194,10 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
                 var dut = new GetInvitationByIdQueryHandler(context, _meetingClientMock.Object);
 
                 var result = await dut.Handle(query, default);
-                Assert.AreEqual(1, result.Errors.Count);
-                Assert.AreEqual($"Could not get meeting with id {_invitation.MeetingId} from Fusion", result.Errors[0]);
+                Assert.IsNotNull(result);
+                Assert.AreEqual(ResultType.Ok, result.ResultType);
+                var invitationDto = result.Data;
+                AssertInvitation(invitationDto, _invitation);
             }
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
@@ -130,8 +130,8 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
                     MeetingId = meetingId
                 };
 
-                _mdpInvitation.AddParticipant(functionalRoleParticipant);
-                _mdpInvitation.AddParticipant(personParticipant);
+                _mdpInvitation.AddParticipant(functionalRoleParticipant2);
+                _mdpInvitation.AddParticipant(personParticipant2);
                 _mdpInvitation.AddCommPkg(commPkg);
 
                 context.Invitations.Add(_dpInvitation);

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsByCommPkgNo/GetInvitationsByCommPkgNoQueryHandlerTests.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Infrastructure;
 using Equinor.ProCoSys.IPO.Query.GetInvitationsByCommPkgNo;
 using Equinor.ProCoSys.IPO.Test.Common;
-using Fusion.Integration.Http.Models;
-using Fusion.Integration.Meeting;
-using Fusion.Integration.Meeting.Http.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -26,17 +22,15 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
         private const string _commPkgNo = "CommPkgNo";
         private const string _projectName = "Project1";
 
-        private Mock<IFusionMeetingClient> _meetingClientMock;
-
         protected override void SetupNewDatabase(DbContextOptions<IPOContext> dbContextOptions)
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var MeetingId = new Guid("11111111-2222-2222-2222-333333333333");
-                var PersonAzureOid = new Guid("44444444-5555-5555-5555-666666666666");
-                const string Description = "Description";
+                var meetingId = new Guid("11111111-2222-2222-2222-333333333333");
+                var personAzureOid = new Guid("44444444-5555-5555-5555-666666666666");
+                const string description = "Description";
 
-                var FunctionalRoleParticipant = new Participant(
+                var functionalRoleParticipant = new Participant(
                     TestPlant,
                     Organization.Contractor,
                     IpoParticipantType.FunctionalRole,
@@ -48,7 +42,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
                     null,
                     0);
 
-                var PersonParticipant = new Participant(
+                var personParticipant = new Participant(
                     TestPlant,
                     Organization.ConstructionCompany,
                     IpoParticipantType.Person,
@@ -57,98 +51,64 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
                     "LastName",
                     "UN",
                     "P1@email.com",
-                    PersonAzureOid,
+                    personAzureOid,
                     1);
 
-                var CommPkg = new CommPkg(
+                var commPkg = new CommPkg(
                     TestPlant,
                     _projectName,
                     _commPkgNo,
-                    Description,
+                    description,
                     "OK");
 
-                var McPkg1 = new McPkg(
+                var mcPkg1 = new McPkg(
                     TestPlant,
                     _projectName,
                     _commPkgNo,
                     "McPkgNo1",
-                    Description);
+                    description);
 
-                var McPkg2 = new McPkg(
+                var mcPkg2 = new McPkg(
                     TestPlant,
                     _projectName,
                     _commPkgNo,
                     "McPkgNo2",
-                    Description);
+                    description);
 
-                _dpInvitation = new Invitation(TestPlant, _projectName, "DP Title", "Description1", DisciplineType.DP)
+                _dpInvitation = new Invitation(
+                    TestPlant,
+                    _projectName,
+                    "DP Title",
+                    "Description1",
+                    DisciplineType.DP,
+                    new DateTime(),
+                    new DateTime(),
+                    null)
                 {
-                    MeetingId = MeetingId
+                    MeetingId = meetingId
                 };
 
-                _dpInvitation.AddParticipant(FunctionalRoleParticipant);
-                _dpInvitation.AddParticipant(PersonParticipant);
-                _dpInvitation.AddMcPkg(McPkg1);
-                _dpInvitation.AddMcPkg(McPkg2);
+                _dpInvitation.AddParticipant(functionalRoleParticipant);
+                _dpInvitation.AddParticipant(personParticipant);
+                _dpInvitation.AddMcPkg(mcPkg1);
+                _dpInvitation.AddMcPkg(mcPkg2);
 
-                _mdpInvitation = new Invitation(TestPlant, _projectName, "MDP Title", "Description2", DisciplineType.MDP)
+                _mdpInvitation = new Invitation(
+                    TestPlant,
+                    _projectName,
+                    "MDP Title",
+                    "Description2",
+                    DisciplineType.MDP,
+                    new DateTime(),
+                    new DateTime(),
+                    null)
                 {
-                    MeetingId = MeetingId
+                    MeetingId = meetingId
                 };
 
-                _mdpInvitation.AddParticipant(FunctionalRoleParticipant);
-                _mdpInvitation.AddParticipant(PersonParticipant);
-                _mdpInvitation.AddCommPkg(CommPkg);
-
-                _meetingClientMock = new Mock<IFusionMeetingClient>();
-                _meetingClientMock
-                    .Setup(x => x.GetMeetingAsync(It.IsAny<Guid>(), It.IsAny<Action<ODataQuery>>()))
-                    .Returns(Task.FromResult(
-                        new GeneralMeeting(
-                            new ApiGeneralMeeting()
-                            {
-                                Classification = string.Empty,
-                                Contract = null,
-                                Convention = string.Empty,
-                                DateCreatedUtc = DateTime.MinValue,
-                                DateEnd = new ApiDateTimeTimeZoneModel(),
-                                DateStart = new ApiDateTimeTimeZoneModel(),
-                                ExternalId = null,
-                                Id = MeetingId,
-                                InviteBodyHtml = string.Empty,
-                                IsDisabled = false,
-                                IsOnlineMeeting = false,
-                                Location = string.Empty,
-                                Organizer = new ApiPersonDetailsV1(),
-                                OutlookMode = string.Empty,
-                                Participants = new List<ApiMeetingParticipant>()
-                                {
-                                    new ApiMeetingParticipant()
-                                    {
-                                        Id = Guid.NewGuid(),
-                                        Person = new ApiPersonDetailsV1()
-                                        {
-                                            Id = Guid.NewGuid(),
-                                            Mail = "P1@email.com"
-                                        },
-                                        OutlookResponse = "Required"
-                                    },
-                                    new ApiMeetingParticipant()
-                                    {
-                                        Id = Guid.NewGuid(),
-                                        Person = new ApiPersonDetailsV1()
-                                        {
-                                            Id = Guid.NewGuid(),
-                                            Mail = "FR1@email.com"
-                                        },
-                                        OutlookResponse = "Accepted"
-                                    }
-                                },
-                                Project = null,
-                                ResponsiblePersons = new List<ApiPersonDetailsV1>(),
-                                Series = null,
-                                Title = string.Empty
-                            })));
+                _mdpInvitation.AddParticipant(functionalRoleParticipant);
+                _mdpInvitation.AddParticipant(personParticipant);
+                _mdpInvitation.AddCommPkg(commPkg);
 
                 context.Invitations.Add(_dpInvitation);
                 context.Invitations.Add(_mdpInvitation);
@@ -164,7 +124,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsByCommPkgNoQuery(_commPkgNo, _projectName);
-                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context);
                 var result = await dut.Handle(query, default);
 
                 Assert.AreEqual(ResultType.Ok, result.ResultType);
@@ -177,7 +137,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsByCommPkgNoQuery(_commPkgNo, _projectName);
-                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context);
 
                 var result = await dut.Handle(query, default);
 
@@ -193,27 +153,11 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsByCommPkgNo
         }
 
         [TestMethod]
-        public async Task HandleGetInvitationsByCommPkgNoQuery_ShouldThrowException_IfMeetingIsNotFound()
-        {
-            using var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
-            {
-                _meetingClientMock
-                    .Setup(x => x.GetMeetingAsync(It.IsAny<Guid>(), It.IsAny<Action<ODataQuery>>()))
-                    .Returns(Task.FromResult<GeneralMeeting>(null));
-
-                var query = new GetInvitationsByCommPkgNoQuery(_commPkgNo, _projectName);
-                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
-
-                await Assert.ThrowsExceptionAsync<Exception>(() => dut.Handle(query, default));
-            }
-        }
-
-        [TestMethod]
         public async Task HandleGetInvitationsByCommPkgNoQuery_ShouldReturnEmptyListOfInvitations_IfNoInvitationsFound()
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new GetInvitationsByCommPkgNoQueryHandler(context, _meetingClientMock.Object);
+                var dut = new GetInvitationsByCommPkgNoQueryHandler(context);
 
                 var result = await dut.Handle(new GetInvitationsByCommPkgNoQuery("Unknown", _projectName), default);
                 Assert.AreEqual(0, result.Data.Count);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/IPOContextExtension.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/IPOContextExtension.cs
@@ -67,7 +67,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                 KnownTestData.ProjectName,
                 KnownTestData.InvitationTitle,
                 KnownTestData.InvitationDescription,
-                DisciplineType.DP)
+                DisciplineType.DP,
+                new DateTime(),
+                new DateTime(),
+                null)
             {
                 MeetingId = KnownTestData.MeetingId
             };

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Misc/InvitationHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Misc/InvitationHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Infrastructure;
 using Equinor.ProCoSys.IPO.Test.Common;
@@ -18,7 +19,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Misc
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var invitation = new Invitation(TestPlant, _projectName, "Title", "Description", DisciplineType.DP);
+                var invitation = new Invitation(
+                    TestPlant,
+                    _projectName,
+                    "Title",
+                    "Description",
+                    DisciplineType.DP,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
                 context.Invitations.Add(invitation);
                 context.SaveChangesAsync().Wait();
                 _invitationId = invitation.Id;


### PR DESCRIPTION
DevOps#80104

Workaround so that users getting IPO that are not invited to meeting can get all details, except for outlook response.  Add StartTime, EndTime, and Location to IPO db