### PR TITLE
Bug 80609: Text fields too big for outlook

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
@@ -13,8 +13,8 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
         public const int ProjectNameMinLength = 3;
         public const int ProjectNameMaxLength = 512;
         public const int TitleMinLength = 3;
-        public const int TitleMaxLength = 1024;
-        public const int LocationMaxLength = 1024;
+        public const int TitleMaxLength = 250;
+        public const int LocationMaxLength = 250;
         public const int DescriptionMaxLength = 4096;
 
         private readonly List<McPkg> _mcPkgs = new List<McPkg>();

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210215124321_ChangeMaxLengthLocationTitle.Designer.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210215124321_ChangeMaxLengthLocationTitle.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.ProCoSys.IPO.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
 {
     [DbContext(typeof(IPOContext))]
-    partial class IPOContextModelSnapshot : ModelSnapshot
+    [Migration("20210215124321_ChangeMaxLengthLocationTitle")]
+    partial class ChangeMaxLengthLocationTitle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210215124321_ChangeMaxLengthLocationTitle.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210215124321_ChangeMaxLengthLocationTitle.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
+{
+    public partial class ChangeMaxLengthLocationTitle : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE INVITATIONS SET TITLE=SUBSTRING(TITLE, 1, 250)");
+            migrationBuilder.Sql("UPDATE INVITATIONS SET LOCATION=SUBSTRING(LOCATION, 1, 250)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Invitations",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Location",
+                table: "Invitations",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Invitations",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Location",
+                table: "Invitations",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandValidatorTests.cs
@@ -207,7 +207,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Title must be between 3 and 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters!"));
         }
 
         [TestMethod]
@@ -227,7 +227,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Title must be between 3 and 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters!"));
         }
 
         [TestMethod]
@@ -247,7 +247,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Title must be between 3 and 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters!"));
         }
 
         [TestMethod]
@@ -267,7 +267,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Location cannot be more than 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Location cannot be more than {Invitation.LocationMaxLength} characters!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandValidatorTests.cs
@@ -174,7 +174,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Title must be between 3 and 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters!"));
         }
 
         [TestMethod]
@@ -195,7 +195,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Title must be between 3 and 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters!"));
         }
 
         [TestMethod]
@@ -216,7 +216,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Title must be between 3 and 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters!"));
         }
 
         [TestMethod]
@@ -237,7 +237,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Location cannot be more than 1024 characters!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Location cannot be more than {Invitation.LocationMaxLength} characters!"));
         }
 
         [TestMethod]


### PR DESCRIPTION
- Change max length values as suggested in task [AB#80609](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80609)