### PR TITLE
80635-Rename IncludeInstallations Param

### DIFF
--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/MainApiProjectService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/MainApiProjectService.cs
@@ -37,7 +37,8 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Project
             var url = $"{_baseAddress}Projects" +
                       $"?plantId={plant}" +
                       $"&api-version={_apiVersion}" +
-                      "&includeInstallations=false";
+                      "&includeInstallations=false" + // Todo Delete this line and comment below after MainApi 4.46 is released. It's OK to use "unknown" params to an endpoint
+                      "&includeSubProjectsOnly=true";  // Use 4.46 param
 
             var projects = await _foreignApiClient.QueryAndDeserializeAsync<List<ProCoSysProject>>(url);
 


### PR DESCRIPTION
Add a "hack" so IPO api find the same projects from Main API both on 4.45 and after.

This mean that this change should be merged and put into productinon before releasing next Main API using param includeSubProjectsOnly instead.
PR: https://statoildeveloper.visualstudio.com/Statoil.NextGenProCoSys/_git/ProCoSysWebApi/pullrequest/6024?_a=overview