### PR TITLE
Revert "Temporarily changed docker sdk image (#78)"

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Dockerfile
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 
 # Copy project files separately and restore NuGet packages to create layers. Skip test projects!


### PR DESCRIPTION
The issue has been fixed.
This reverts commit 33e4d2554f3f450694742967305e3b3f02b6ac71.