### PR TITLE
80726 Consistency in outlook response

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/MeetingInvitationHelper.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/MeetingInvitationHelper.cs
@@ -5,7 +5,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
     public class MeetingInvitationHelper
     {
         public static string GenerateMeetingTitle(Invitation invitation) 
-            => $"Invitation to Punch Out, IPO-{invitation.Id}, Project: {invitation.ProjectName}";
+            => $"Invitation for punch-out, IPO-{invitation.Id}, Project: {invitation.ProjectName}";
 
         public static string GenerateMeetingDescription(Invitation invitation, string baseUrl)
         {
@@ -28,7 +28,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
                 meetingDescription += GenerateCommPkgTable(invitation, baseUrl);
             }
 
-            meetingDescription += $"</br><a href='{baseUrl}" + $"/InvitationForPunchOut/{invitation.Id}'>" + "Open invitation for punch out in ProCoSys.</a>";
+            meetingDescription += $"</br><a href='{baseUrl}" + $"/InvitationForPunchOut/{invitation.Id}'>" + "Open invitation for punch-out in ProCoSys.</a>";
 
             return meetingDescription;
         }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -140,15 +140,14 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         personInFunctionalRole.Response = functionalRolePersonResponse;
                     }
 
-                    OutlookResponse? functionalRoleResponse = OutlookResponse.None;
-                    if (participant.FunctionalRole.Email != null)
+                    OutlookResponse? functionalRoleResponse = null;
+                    if (participant.FunctionalRole.Email != null && meeting != null)
                     {
-                        functionalRoleResponse = meeting != null
-                            ? GetOutlookResponseByEmailAsync(meeting, participant.FunctionalRole.Email)
-                            : null;
+                        functionalRoleResponse =
+                            GetOutlookResponseByEmailAsync(meeting, participant.FunctionalRole.Email);
                     }
 
-                    if (participant.FunctionalRole.Persons != null)
+                    if (participant.FunctionalRole.Persons != null && meeting != null)
                     {
                         functionalRoleResponse = GetOutlookResponseForFunctionalRole(
                             participant.FunctionalRole.Persons.ToList(),

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -106,18 +106,14 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             {
                 if (participant.Person != null)
                 {
-                    OutlookResponse? participantPersonResponse;
+                    OutlookResponse? participantPersonResponse = null;
                     if (meeting != null)
                     {
                         participantPersonResponse = participant.Person.Person.AzureOid == meeting.Organizer.Id
                             ? OutlookResponse.Organizer
                             : GetOutlookResponseByEmailAsync(meeting, participant.Person?.Person?.Email);
                     }
-                    else
-                    {
-                        participantPersonResponse = null;
-                    }
-                    
+
                     participant.Person.Response = participantPersonResponse;
                 }
 

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -106,11 +106,12 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             {
                 if (participant.Person != null)
                 {
-                    var participantPersonResponse = participant.Person.Person.AzureOid == meeting.Organizer.Id
-                                                    ? OutlookResponse.Organizer
-                                                    : meeting != null
-                                                    ? GetOutlookResponseByEmailAsync(meeting, participant.Person?.Person?.Email)
-                                                    : null;
+                    var participantPersonResponse = meeting != null 
+                            ? participant.Person.Person.AzureOid == meeting.Organizer.Id
+                            ? OutlookResponse.Organizer
+                            : GetOutlookResponseByEmailAsync(meeting, participant.Person?.Person?.Email)
+                            : null;
+                    
                     participant.Person.Response = participantPersonResponse;
                 }
 

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -166,7 +166,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             {
                 return OutlookResponse.TentativelyAccepted;
             }
-            return persons.Any(p => p.Response == OutlookResponse.Declined) ? OutlookResponse.Declined : OutlookResponse.None;
+            return persons.Any(p => p.Response == OutlookResponse.Declined) || frResponse == OutlookResponse.Declined 
+                ? OutlookResponse.Declined : OutlookResponse.None;
         }
 
         private static ParticipantType? GetParticipantTypeByEmail(GeneralMeeting meeting, string email) 


### PR DESCRIPTION
DevOps#80726

Consistency in null and none as outlook response. Always return null is person getting meeting does not have access to meeting.