### PR TITLE
81792 Integration test cleanup

### DIFF
--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
@@ -203,15 +203,10 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
                 .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
                     _azureOidForCurrentUser.ToString(), _functionalRoleCode))
                 .Returns(Task.FromResult<ProCoSysPerson>(null));
-            
-            var command = new CompletePunchOutCommand(
-                _invitation.Id,
-                _invitationRowVersion,
-                _participantRowVersion,
-                _participantsToChange);
-
+  
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
+                _dut.Handle(_command, default));
+
             Assert.IsTrue(result.Message.StartsWith("Person was not found in functional role with code"));
             _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
         }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -307,20 +307,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
                     _azureOid.ToString(), "IPO", new List<string> { "SIGN" }))
                 .Returns(Task.FromResult<ProCoSysPerson>(null));
 
-            var command = new CreateInvitationCommand(
-                _title,
-                _description,
-                _location,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _projectName,
-                _type,
-                _participants,
-                _mcPkgScope ,
-                null);
-
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
+                _dut.Handle(_command, default));
             Assert.IsTrue(result.Message.StartsWith("Person does not have required privileges to be the"));
         }
 
@@ -333,20 +321,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
                     _plant, new List<string> {_functionalRoleCode}))
                 .Returns(Task.FromResult(functionalRoles));
 
-            var command = new CreateInvitationCommand(
-                _title,
-                _description,
-                _location,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _projectName,
-                _type,
-                _participants,
-                _mcPkgScope,
-                null);
-
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
+                _dut.Handle(_command, default));
             Assert.IsTrue(result.Message.StartsWith("Could not find functional role with functional role code"));
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -284,7 +284,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
             Assert.IsTrue(result.Message.StartsWith("Comm pkg scope must be within a system"));
-
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -363,8 +363,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 null,
                 _rowVersion);
 
-            await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Mc pkg scope must be within a system"));
         }
 
         [TestMethod]
@@ -396,8 +397,62 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 newScope,
                 _rowVersion);
 
-            await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Comm pkg scope must be within a system"));
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfSigningParticipantDoesNotHaveCorrectPrivileges()
+        {
+            _personApiServiceMock
+                .Setup(x => x.GetPersonByOidWithPrivilegesAsync(_plant,
+                    _newAzureOid.ToString(), "IPO", new List<string> { "SIGN" }))
+                .Returns(Task.FromResult<ProCoSysPerson>(null));
+
+            var command = new EditInvitationCommand(
+                _invitation.Id,
+                _newTitle,
+                _newDescription,
+                null,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _type,
+                _updatedParticipants,
+                _mcPkgScope,
+                null,
+                _rowVersion);
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Person does not have required privileges to be the"));
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfFunctionalRoleDoesNotExistOrHaveIPOClassification()
+        {
+            IList<ProCoSysFunctionalRole> functionalRoles = new List<ProCoSysFunctionalRole>();
+            _functionalRoleApiServiceMock
+                .Setup(x => x.GetFunctionalRolesByCodeAsync(
+                    _plant, new List<string> { _newFunctionalRoleCode }))
+                .Returns(Task.FromResult(functionalRoles));
+
+            var command = new EditInvitationCommand(
+                _invitation.Id,
+                _newTitle,
+                _newDescription,
+                null,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _type,
+                _updatedParticipants,
+                _mcPkgScope,
+                null,
+                _rowVersion);
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Could not find functional role with functional role code"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -410,21 +410,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                     _newAzureOid.ToString(), "IPO", new List<string> { "SIGN" }))
                 .Returns(Task.FromResult<ProCoSysPerson>(null));
 
-            var command = new EditInvitationCommand(
-                _invitation.Id,
-                _newTitle,
-                _newDescription,
-                null,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _type,
-                _updatedParticipants,
-                _mcPkgScope,
-                null,
-                _rowVersion);
-
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
+                _dut.Handle(_command, default));
             Assert.IsTrue(result.Message.StartsWith("Person does not have required privileges to be the"));
         }
 
@@ -437,21 +424,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                     _plant, new List<string> { _newFunctionalRoleCode }))
                 .Returns(Task.FromResult(functionalRoles));
 
-            var command = new EditInvitationCommand(
-                _invitation.Id,
-                _newTitle,
-                _newDescription,
-                null,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _type,
-                _updatedParticipants,
-                _mcPkgScope,
-                null,
-                _rowVersion);
-
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
+                _dut.Handle(_command, default));
             Assert.IsTrue(result.Message.StartsWith("Could not find functional role with functional role code"));
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
@@ -168,6 +168,21 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
         }
 
         [TestMethod]
+        public async Task ChangeAttendedStatusesCommand_ShouldThrowErrorIfPersonIsNotInFunctionalRole()
+        {
+            _personApiServiceMock
+                .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
+                    _azureOidForCurrentUser.ToString(), _functionalRoleCode))
+                .Returns(Task.FromResult<ProCoSysPerson>(null));
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(_command, default));
+
+            Assert.IsTrue(result.Message.StartsWith("Person was not found in functional role with code"));
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
         public async Task HandlingCompleteIpoCommand_ShouldSetVersions()
         {
             // Act

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -52,6 +52,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess, 
                 9999, 
                 HttpStatusCode.NotFound);
+
+        [TestMethod]
+        public async Task GetInvitation_AsSigner_ShouldReturnNotFound_WhenUnknownId()
+            => await InvitationsControllerTestsHelper.GetInvitationAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                9999,
+                HttpStatusCode.NotFound);
         #endregion
 
         #region ExportInvitations
@@ -309,6 +317,19 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new EditInvitationDto(),
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task EditInvitation_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+        {
+            var editInvitationDto = await CreateValidEditInvitationDto();
+            await InvitationsControllerTestsHelper.EditInvitationAsync(
+                    UserType.Planner,
+                    TestFactory.PlantWithAccess,
+                    38934,
+                    editInvitationDto,
+                    HttpStatusCode.BadRequest,
+                    "IPO with this ID does not exist!");
+        }
         #endregion
 
         #region Sign 
@@ -504,6 +525,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new UnCompletePunchOutDto(),
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnCompletePunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.UnCompletePunchOutAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                9999,
+                new UnCompletePunchOutDto(),
+                HttpStatusCode.BadRequest);
         #endregion
 
         #region Accept
@@ -562,6 +592,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new AcceptPunchOutDto(),
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task AcceptPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.AcceptPunchOutAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                9999,
+                new AcceptPunchOutDto(),
+                HttpStatusCode.BadRequest);
         #endregion
 
         #region UnAccept
@@ -611,6 +650,16 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new UnAcceptPunchOutDto(),
                 HttpStatusCode.Forbidden);
+
+
+        [TestMethod]
+        public async Task UnAcceptPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.UnAcceptPunchOutAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                9999,
+                new UnAcceptPunchOutDto(),
+                HttpStatusCode.BadRequest);
         #endregion
 
         #region Cancel
@@ -660,6 +709,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new CancelPunchOutDto(),
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CancelPunchOut_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.CancelPunchOutAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                9999,
+                new CancelPunchOutDto(),
+                HttpStatusCode.BadRequest);
         #endregion
 
         #region ChangeAttendedStatusOnParticipants
@@ -700,6 +758,19 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new ParticipantToChangeDto[1],
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task ChangeAttendedStatusOnParticipants_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                9999,
+                new[] {new ParticipantToChangeDto
+                {
+                    Attended = true, Id = 1, Note = "note", RowVersion = TestFactory.AValidRowVersion
+                }},
+                HttpStatusCode.BadRequest);
+
         #endregion
 
         #region UploadAttachment
@@ -740,6 +811,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 FileToBeUploaded,
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UploadAttachment_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.UploadAttachmentAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                9999,
+                FileToBeUploaded,
+                HttpStatusCode.BadRequest);
         #endregion
 
         #region DeleteAttachment
@@ -784,6 +864,16 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Attachment doesn't exist!");
+
+        [TestMethod]
+        public async Task DeleteAttachment_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.DeleteAttachmentAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                9999,
+                _attachmentId,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest);
         #endregion
 
         #region GetAttachments

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -298,7 +298,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 new EditInvitationDto(),
                 HttpStatusCode.Forbidden);
 
-
         [TestMethod]
         public async Task EditInvitation_AsViewer_ShouldReturnForbidden_WhenPermissionMissing()
             => await InvitationsControllerTestsHelper.EditInvitationAsync(
@@ -322,12 +321,12 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         {
             var editInvitationDto = await CreateValidEditInvitationDto();
             await InvitationsControllerTestsHelper.EditInvitationAsync(
-                    UserType.Planner,
-                    TestFactory.PlantWithAccess,
-                    38934,
-                    editInvitationDto,
-                    HttpStatusCode.BadRequest,
-                    "IPO with this ID does not exist!");
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                38934,
+                editInvitationDto,
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         }
         #endregion
 
@@ -404,7 +403,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 new CompletePunchOutDto(),
                 HttpStatusCode.Unauthorized);
-
 
         [TestMethod]
         public async Task CompletePunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownPlant()

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -308,7 +308,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 new EditInvitationDto(),
                 HttpStatusCode.Forbidden);
 
-
         [TestMethod]
         public async Task EditInvitation_AsSigner_ShouldReturnForbidden_WhenPermissionMissing()
             => await InvitationsControllerTestsHelper.EditInvitationAsync(
@@ -770,7 +769,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     Attended = true, Id = 1, Note = "note", RowVersion = TestFactory.AValidRowVersion
                 }},
                 HttpStatusCode.BadRequest);
-
         #endregion
 
         #region UploadAttachment

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -103,7 +103,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             );
 
             var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToSignId);
 
@@ -120,7 +120,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Assert
             var signedInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToSignId);
 
@@ -131,7 +131,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         }
 
         [TestMethod]
-        public async Task CompletePunchOut_AsCompleter_ShouldCompletePunchOut()
+        public async Task CompletePunchOut_AsSigner_ShouldCompletePunchOut()
         {
             // Arrange
             var invitationToCompleteId = await InvitationsControllerTestsHelper.CreateInvitationAsync(
@@ -174,14 +174,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.CompletePunchOutAsync(
-                UserType.Completer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToCompleteId,
                 completePunchOutDto);
 
             // Assert
             var completedInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToCompleteId);
 
@@ -189,12 +189,12 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 completedInvitation.Participants.Single(p => p.Person?.Person.Id == completerPerson.Person.Id);
             Assert.AreEqual(IpoStatus.Completed, completedInvitation.Status);
             Assert.IsNotNull(completingParticipant.SignedAtUtc);
-            Assert.AreEqual(_conradContractor.AzureOid, completingParticipant.SignedBy.AzureOid.ToString());
+            Assert.AreEqual(_sigurdSigner.AzureOid, completingParticipant.SignedBy.AzureOid.ToString());
             AssertRowVersionChange(invitation.RowVersion, newRowVersion);
         }
 
         [TestMethod]
-        public async Task UnCompletePunchOut_AsCompleter_ShouldUnCompletePunchOut()
+        public async Task UnCompletePunchOut_AsSigner_ShouldUnCompletePunchOut()
         {
             // Arrange
             var invitationToUnCompletedId = await InvitationsControllerTestsHelper.CreateInvitationAsync(
@@ -212,7 +212,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             );
 
             var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnCompletedId);
 
@@ -237,7 +237,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Punch round must be completed before it can be uncompleted
             var newInvitationRowVersion = await InvitationsControllerTestsHelper.CompletePunchOutAsync(
-                UserType.Completer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnCompletedId,
                 completePunchOutDto);
@@ -250,14 +250,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.UnCompletePunchOutAsync(
-                UserType.Completer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnCompletedId,
                 unCompletePunchOutDto);
 
             // Assert
             var unCompletedInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnCompletedId);
 
@@ -272,7 +272,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         }
 
         [TestMethod]
-        public async Task AcceptPunchOut_AsAccepter_ShouldAcceptPunchOut()
+        public async Task AcceptPunchOut_AsSigner_ShouldAcceptPunchOut()
         {
             // Arrange
             var invitationToAcceptId = await InvitationsControllerTestsHelper.CreateInvitationAsync(
@@ -290,7 +290,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             );
 
             var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToAcceptId);
 
@@ -315,7 +315,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Punch round must be completed before it can be accepted
             var newRowVersion = await InvitationsControllerTestsHelper.CompletePunchOutAsync(
-                UserType.Completer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToAcceptId,
                 completePunchOutDto);
@@ -340,14 +340,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Act
             newRowVersion = await InvitationsControllerTestsHelper.AcceptPunchOutAsync(
-                UserType.Accepter,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToAcceptId,
                 acceptPunchOutDto);
 
             // Assert
             var acceptedInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToAcceptId);
 
@@ -355,12 +355,12 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 acceptedInvitation.Participants.Single(p => p.Person?.Person.Id == accepterPerson.Person.Id);
             Assert.AreEqual(IpoStatus.Accepted, acceptedInvitation.Status);
             Assert.IsNotNull(acceptingParticipant.SignedAtUtc);
-            Assert.AreEqual(_connieConstructor.AzureOid, acceptingParticipant.SignedBy.AzureOid.ToString());
+            Assert.AreEqual(_sigurdSigner.AzureOid, acceptingParticipant.SignedBy.AzureOid.ToString());
             AssertRowVersionChange(invitation.RowVersion, newRowVersion);
         }
 
         [TestMethod]
-        public async Task UnAcceptPunchOut_AsAccepter_ShouldUnAcceptPunchOut()
+        public async Task UnAcceptPunchOut_AsSigner_ShouldUnAcceptPunchOut()
         {
             // Arrange
             var invitationToUnAcceptId = await InvitationsControllerTestsHelper.CreateInvitationAsync(
@@ -378,7 +378,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             );
 
             var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnAcceptId);
 
@@ -403,7 +403,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Punch round must be completed before it can be accepted
             var newInvitationRowVersion = await InvitationsControllerTestsHelper.CompletePunchOutAsync(
-                UserType.Completer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnAcceptId,
                 completePunchOutDto);
@@ -428,13 +428,13 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Punch round must be accepted before it can be unaccepted
             await InvitationsControllerTestsHelper.AcceptPunchOutAsync(
-                UserType.Accepter,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnAcceptId,
                 acceptPunchOutDto);
 
             invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnAcceptId);
 
@@ -449,7 +449,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.UnAcceptPunchOutAsync(
-                UserType.Accepter,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToUnAcceptId,
                 unAcceptPunchOutDto);
@@ -469,7 +469,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         }
 
         [TestMethod]
-        public async Task ChangeAttendedStatusOnParticipants_AsCompleter_ShouldChangeAttendedStatus()
+        public async Task ChangeAttendedStatusOnParticipants_AsSigner_ShouldChangeAttendedStatus()
         {
             //Arrange
             const string updatedNote = "Updated note about attendee";
@@ -489,7 +489,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             );
 
             var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToChangeId);
 
@@ -513,7 +513,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 };
 
                 await InvitationsControllerTestsHelper.CompletePunchOutAsync(
-                    UserType.Completer,
+                    UserType.Signer,
                     TestFactory.PlantWithAccess,
                     invitationToChangeId,
                     completePunchOutDto);
@@ -531,14 +531,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             //Act
             await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
-                UserType.Completer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToChangeId,
                 participantToChangeDto);
 
             //Assert
             var invitationWithUpdatedAttendedStatus = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Viewer,
+                UserType.Signer,
                 TestFactory.PlantWithAccess,
                 invitationToChangeId);
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -38,17 +38,13 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
         protected readonly TestFile FileToBeUploaded = new TestFile("test file content", "file.txt");
         protected readonly TestFile FileToBeUploaded2 = new TestFile("test file 2 content", "file2.txt");
-        protected PersonHelper _sigurdSigner, _connieConstructor, _conradContractor, _pernillaPlanner;
+        protected PersonHelper _sigurdSigner, _pernillaPlanner;
 
         [TestInitialize]
         public void TestInitialize()
         {
             var personParticipant = new PersonForCommand(Guid.NewGuid(), "ola@test.com", true);
             var functionalRoleParticipant = new FunctionalRoleForCommand(FunctionalRoleCode, null);
-            var completerUser = TestFactory.Instance.GetTestUserForUserType(UserType.Completer);
-            _conradContractor = new PersonHelper(completerUser.Profile.Oid, "Conrad", "Contractor", "ConradUserName","conrad@contractor.com", 1, "AAAAAAAAALA=");
-            var accepterUser = TestFactory.Instance.GetTestUserForUserType(UserType.Accepter);
-            _connieConstructor = new PersonHelper(accepterUser.Profile.Oid, "Connie", "Constructor", "ConnieUserName", "connie@constructor.com", 2, "AAAAAAAAABA=");
             var signerUser = TestFactory.Instance.GetTestUserForUserType(UserType.Signer);
             _sigurdSigner = new PersonHelper(signerUser.Profile.Oid, "Sigurd", "Signer", "SigurdUserName", "sigurd@signer.com", 3, "AAAAAAAAAMA=");
             var plannerUser = TestFactory.Instance.GetTestUserForUserType(UserType.Planner);
@@ -75,13 +71,13 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 new ParticipantsForCommand(
                     Organization.Contractor,
                     null,
-                    _conradContractor.AsPersonForCommand(true),
+                    _sigurdSigner.AsPersonForCommand(true),
                     null,
                     0),
                 new ParticipantsForCommand(
                     Organization.ConstructionCompany,
                     null,
-                    _connieConstructor.AsPersonForCommand(true),
+                    _sigurdSigner.AsPersonForCommand(true),
                     null,
                     1),
                 new ParticipantsForCommand(
@@ -194,24 +190,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     "IPO",
                     It.IsAny<List<string>>()))
                 .Returns(Task.FromResult(_sigurdSigner.AsProCoSysPerson()));
-
-            TestFactory.Instance
-                .PersonApiServiceMock
-                .Setup(x => x.GetPersonByOidWithPrivilegesAsync(
-                    TestFactory.PlantWithAccess,
-                    _connieConstructor.AzureOid,
-                    "IPO",
-                    It.IsAny<List<string>>()))
-                .Returns(Task.FromResult(_connieConstructor.AsProCoSysPerson()));
-
-            TestFactory.Instance
-                .PersonApiServiceMock
-                .Setup(x => x.GetPersonByOidWithPrivilegesAsync(
-                    TestFactory.PlantWithAccess,
-                    _conradContractor.AzureOid,
-                    "IPO",
-                    It.IsAny<List<string>>()))
-                .Returns(Task.FromResult(_conradContractor.AsProCoSysPerson()));
 
             TestFactory.Instance
                 .PersonApiServiceMock

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Participants/ParticipantsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Participants/ParticipantsControllerTests.cs
@@ -63,11 +63,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Participants
                 "RequiredSignersSearchString");
 
             // Assert
-            Assert.AreEqual(2, signerPersons.Count);
-            var requiredSignerPerson = signerPersons.First();
-            Assert.AreEqual("ConnieUserName", requiredSignerPerson.UserName);
-            Assert.AreEqual("Connie", requiredSignerPerson.FirstName);
-            Assert.AreEqual("Constructor", requiredSignerPerson.LastName);
+            Assert.AreEqual(1, signerPersons.Count);
+            var requiredSignerPerson = signerPersons.Single();
+            Assert.AreEqual("SigurdUserName", requiredSignerPerson.UserName);
+            Assert.AreEqual("Sigurd", requiredSignerPerson.FirstName);
+            Assert.AreEqual("Signer", requiredSignerPerson.LastName);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Participants/ParticipantsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Participants/ParticipantsControllerTestsBase.cs
@@ -16,23 +16,16 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Participants
         private const string Classification = "IPO";
         private const string AzureOid = "47ff6258-0906-4849-add8-aada76ee0b0d";
        
-        protected PersonHelper _sigurdSigner, _connieConstructor, _conradContractor, _vidarViewer;
+        protected PersonHelper _sigurdSigner, _vidarViewer;
 
         private IList<ProCoSysFunctionalRole> _pcsFunctionalRoles;
         private List<ProCoSysPerson> _personsInFunctionalRole;
-        private IList<ProCoSysPerson> _requiredSignerPersons;
-        private IList<ProCoSysPerson> _additionalSignerPersons;
+        private IList<ProCoSysPerson> _signerPersons;
         private IList<ProCoSysPerson> _proCoSysPersons;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            var completerUser = TestFactory.Instance.GetTestUserForUserType(UserType.Completer);
-            _conradContractor = new PersonHelper(completerUser.Profile.Oid, "Conrad", "Contractor", "ConradUserName",
-                "conrad@contractor.com", 1, "AAAAAAAAALA=");
-            var accepterUser = TestFactory.Instance.GetTestUserForUserType(UserType.Accepter);
-            _connieConstructor = new PersonHelper(accepterUser.Profile.Oid, "Connie", "Constructor", "ConnieUserName",
-                "connie@constructor.com", 2, "AAAAAAAAABA=");
             var signerUser = TestFactory.Instance.GetTestUserForUserType(UserType.Signer);
             _sigurdSigner = new PersonHelper(signerUser.Profile.Oid, "Sigurd", "Signer", "SigurdUserName",
                 "sigurd@signer.com", 3, "AAAAAAAAAMA=");
@@ -74,13 +67,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Participants
                 }
             };
 
-            _requiredSignerPersons = new List<ProCoSysPerson>
-            {
-                _connieConstructor.AsProCoSysPerson(),
-                _conradContractor.AsProCoSysPerson()
-            };
-
-            _additionalSignerPersons = new List<ProCoSysPerson>
+            _signerPersons = new List<ProCoSysPerson>
             {
                 _sigurdSigner.AsProCoSysPerson()
             };
@@ -120,7 +107,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Participants
                     "RequiredSignersSearchString",
                     "IPO",
                     It.IsAny<List<string>>()))
-                .Returns(Task.FromResult(_requiredSignerPersons));
+                .Returns(Task.FromResult(_signerPersons));
 
             TestFactory.Instance
                 .PersonApiServiceMock
@@ -129,7 +116,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Participants
                     "AdditionalSignersSearchString",
                     "IPO",
                     It.IsAny<List<string>>()))
-                .Returns(Task.FromResult(_additionalSignerPersons));
+                .Returns(Task.FromResult(_signerPersons));
 
             TestFactory.Instance
                 .PersonApiServiceMock

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -294,10 +294,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
 
             AddSignerUser(commonProCoSysPlants, commonProCoSysProjects);
             
-            AddCompleterUser(commonProCoSysPlants, commonProCoSysProjects);
-
-            AddAccepterUser(commonProCoSysPlants, commonProCoSysProjects);
-
             AddPlannerUser(commonProCoSysPlants, commonProCoSysProjects);
 
             AddViewerUser(commonProCoSysPlants, commonProCoSysProjects);
@@ -371,7 +367,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                     ProCoSysProjects = commonProCoSysProjects
                 });
 
-        // Authenticated user with necessary permissions to SIGN invitations
+        // Authenticated user with necessary permissions to SIGN invitations (including completing and accepting)
         private void AddSignerUser(
             List<ProCoSysPlant> commonProCoSysPlants,
             List<ProCoSysProject> commonProCoSysProjects)
@@ -385,64 +381,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                             Oid = SignerOid,
                             UserName = "sigurdsigner",
                             Email = "sigurd.signer@pcs.pcs"
-                        },
-                    ProCoSysPlants = commonProCoSysPlants,
-                    ProCoSysPermissions = new List<string>
-                    {
-                        Permissions.COMMPKG_READ,
-                        Permissions.MCPKG_READ,
-                        Permissions.PROJECT_READ,
-                        Permissions.LIBRARY_FUNCTIONAL_ROLE_READ,
-                        Permissions.USER_READ,
-                        Permissions.IPO_READ,
-                        Permissions.IPO_SIGN
-                    },
-                    ProCoSysProjects = commonProCoSysProjects
-                });
-
-        // Authenticated user with necessary permissions to COMPLETE invitations
-        private void AddCompleterUser(
-            List<ProCoSysPlant> commonProCoSysPlants,
-            List<ProCoSysProject> commonProCoSysProjects)
-            => _testUsers.Add(UserType.Completer,
-                new TestUser
-                {
-                    Profile =
-                        new TestProfile
-                        {
-                            FullName = "Conrad Contractor",
-                            Oid = CompleterOid,
-                            UserName = "conradcontractor",
-                            Email = "conrad.contractor@pcs.pcs"
-                        },
-                    ProCoSysPlants = commonProCoSysPlants,
-                    ProCoSysPermissions = new List<string>
-                    {
-                        Permissions.COMMPKG_READ,
-                        Permissions.MCPKG_READ,
-                        Permissions.PROJECT_READ,
-                        Permissions.LIBRARY_FUNCTIONAL_ROLE_READ,
-                        Permissions.USER_READ,
-                        Permissions.IPO_READ,
-                        Permissions.IPO_SIGN
-                    },
-                    ProCoSysProjects = commonProCoSysProjects
-                });
-
-        // Authenticated user with necessary permissions to ACCEPT invitations
-        private void AddAccepterUser(
-            List<ProCoSysPlant> commonProCoSysPlants,
-            List<ProCoSysProject> commonProCoSysProjects)
-            => _testUsers.Add(UserType.Accepter,
-                new TestUser
-                {
-                    Profile =
-                        new TestProfile
-                        {
-                            FullName = "Connie Constructor",
-                            Oid = AccepterOid,
-                            UserName = "connieconstructor",
-                            Email = "connie.constructor@pcs.pcs"
                         },
                     ProCoSysPlants = commonProCoSysPlants,
                     ProCoSysPermissions = new List<string>

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -39,8 +39,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         private const string PlannerOid = "00000000-0000-0000-0000-000000000002";
         private const string ViewerOid = "00000000-0000-0000-0000-000000000003";
         private const string HackerOid = "00000000-0000-0000-0000-000000000666";
-        private const string CompleterOid = "00000000-0000-0000-0000-000000000453";
-        private const string AccepterOid = "00000000-0000-0000-0000-000000000234";
 
         private const string IntegrationTestEnvironment = "IntegrationTests";
         private readonly string _connectionString;

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
@@ -4,8 +4,6 @@
     {
         Anonymous,
         Signer,
-        Completer,
-        Accepter,
         Planner,
         Viewer,
         Hacker


### PR DESCRIPTION
[AB#81792](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81792)

**Test cleanup**

Integration tests:
-Removed completor and acceptor - use Signer for all types of signing (including completing and accepting)
-Removed integration tests that are covered in unit tests
-In positive tests such as "complete_invitation_asSigner", I made the getInvitation-requests be done by signer as well, instead of by viewer. For me this makes more sense that it is the signer that is retrieving the IPO before completing. **_LET ME KNOW IF THIS IS WRONG OR DOESNT MAKE SENSE TO YOU._**

Unit tests:
-Added tests to cover validation being done in command handlers (because we are using main API to do some validation)