### PR TITLE
81895 Error if invalid scope

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -331,6 +331,11 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             var commPkgDetailsList =
                 await _commPkgApiService.GetCommPkgsByCommPkgNosAsync(_plantProvider.Plant, projectName, commPkgScope);
 
+            if (commPkgDetailsList.Count != commPkgScope.Count)
+            {
+                throw new IpoValidationException("Could not find all comm pkgs in scope.");
+            }
+
             var initialCommPkg = commPkgDetailsList.FirstOrDefault();
             if (initialCommPkg != null)
             {
@@ -357,6 +362,12 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         {
             var mcPkgDetailsList =
                 await _mcPkgApiService.GetMcPkgsByMcPkgNosAsync(_plantProvider.Plant, projectName, mcPkgScope);
+
+            if (mcPkgDetailsList.Count != mcPkgScope.Count)
+            {
+                throw new IpoValidationException("Could not find all mc pkgs in scope.");
+            }
+
             var initialMcPkg = mcPkgDetailsList.FirstOrDefault();
             if (initialMcPkg != null)
             {
@@ -366,6 +377,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                     throw new IpoValidationException("Mc pkg scope must be within a system.");
                 }
             }
+
             foreach (var mcPkg in mcPkgDetailsList)
             {
                 invitation.AddMcPkg(new McPkg(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -128,6 +128,12 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         {
             var mcPkgDetailsList =
                 await _mcPkgApiService.GetMcPkgsByMcPkgNosAsync(_plantProvider.Plant, projectName, mcPkgNos);
+
+            if (mcPkgDetailsList.Count != mcPkgNos.Count)
+            {
+                throw new IpoValidationException("Could not find all mc pkgs in scope.");
+            }
+
             var initialMcPkg = mcPkgDetailsList.FirstOrDefault();
             if (initialMcPkg != null)
             {
@@ -182,6 +188,11 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         {
             var commPkgDetailsList =
                 await _commPkgApiService.GetCommPkgsByCommPkgNosAsync(_plantProvider.Plant, projectName, newCommPkgNos);
+            
+            if (commPkgDetailsList.Count != newCommPkgNos.Count)
+            {
+                throw new IpoValidationException("Could not find all comm pkgs in scope.");
+            }
 
             var initialCommPkg = commPkgDetailsList.FirstOrDefault();
             if (initialCommPkg != null)


### PR DESCRIPTION
[AB#81895](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81895)

Throw validation error if the user is adding scope that is not found in main by the GetBy___PkgNos-endpoints. E.g. adding a commpkgno that is not found in GetByCommPkgNos endpoint.

(This bug was discovered when I tried to add a decommissioning pkg as scope. Endpoints in main do not get decommisioning pkgs (this will be changed), so I was able to create an IPO without a scope)