### PR TITLE
Moving fusion call from bus receive to direct call pre-save

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandler.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
+using Fusion.Integration.Meeting;
 using MediatR;
 using ServiceResult;
 
@@ -13,17 +15,20 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
         private readonly IInvitationRepository _invitationRepository;
         private readonly IPersonRepository _personRepository;
         private readonly IUnitOfWork _unitOfWork;
+        private readonly IFusionMeetingClient _meetingClient;
         private readonly ICurrentUserProvider _currentUserProvider;
 
         public CancelPunchOutCommandHandler(
             IInvitationRepository invitationRepository,
             IPersonRepository personRepository,
             IUnitOfWork unitOfWork,
+            IFusionMeetingClient meetingClient,
             ICurrentUserProvider currentUserProvider)
         {
             _invitationRepository = invitationRepository;
             _personRepository = personRepository;
             _unitOfWork = unitOfWork;
+            _meetingClient = meetingClient;
             _currentUserProvider = currentUserProvider;
         }
 
@@ -34,8 +39,22 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
             invitation.CancelIpo(currentUser);
             invitation.SetRowVersion(request.RowVersion);
 
+            await CancelFusionMeetingAsync(invitation.MeetingId);
+
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             return new SuccessResult<string>(invitation.RowVersion.ConvertToString());
+        }
+
+        private async Task CancelFusionMeetingAsync(Guid meetingId)
+        {
+            try
+            {
+                await _meetingClient.DeleteMeetingAsync(meetingId);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Error: Could not cancel outlook meeting.", e);
+            }
         }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
@@ -15,7 +15,6 @@ using Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg;
 using Equinor.ProCoSys.IPO.WebApi.Authentication;
 using Equinor.ProCoSys.IPO.WebApi.Misc;
 using Equinor.ProCoSys.IPO.WebApi.Telemetry;
-using Fusion.Integration.Meeting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
@@ -27,7 +26,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
         private readonly IUnitOfWork _unitOfWork;
         private readonly ITelemetryClient _telemetryClient;
         private readonly IReadOnlyContext _context;
-        private readonly IFusionMeetingClient _meetingClient;
         private readonly IMcPkgApiService _mcPkgApiService;
         private readonly IApplicationAuthenticator _authenticator;
         private readonly IBearerTokenSetter _bearerTokenSetter;
@@ -39,7 +37,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
             IUnitOfWork unitOfWork,
             ITelemetryClient telemetryClient,
             IReadOnlyContext context,
-            IFusionMeetingClient meetingClient,
             IMcPkgApiService mcPkgApiService,
             IApplicationAuthenticator authenticator,
             IBearerTokenSetter bearerTokenSetter)
@@ -49,7 +46,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
             _unitOfWork = unitOfWork;
             _telemetryClient = telemetryClient;
             _context = context;
-            _meetingClient = meetingClient;
             _mcPkgApiService = mcPkgApiService;
             _authenticator = authenticator;
             _bearerTokenSetter = bearerTokenSetter;
@@ -241,15 +237,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
                 {
                     throw new Exception($"Error: Could not clear M-01 dates for {invitation.ObjectGuid}", e);
                 }
-            }
-
-            try
-            {
-                await _meetingClient.DeleteMeetingAsync(invitation.MeetingId);
-            }
-            catch (Exception e)
-            {
-                throw new Exception($"Error: Could not cancel outlook meeting {invitation.MeetingId}.", e);
             }
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
@@ -27,7 +27,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
         private Mock<IInvitationRepository> _invitationRepository;
         private Mock<IPlantSetter> _plantSetter;
         private Mock<ITelemetryClient> _telemetryClient;
-        private Mock<IFusionMeetingClient> _fusionMeetingClient;
         private Mock<IMcPkgApiService> _mcPkgApiService;
         private Mock<IReadOnlyContext> _readOnlyContext;
         private Mock<IApplicationAuthenticator> _applicationAuthenticator;
@@ -48,7 +47,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _plantSetter = new Mock<IPlantSetter>();
             _unitOfWork = new Mock<IUnitOfWork>();
             _telemetryClient = new Mock<ITelemetryClient>();
-            _fusionMeetingClient = new Mock<IFusionMeetingClient>();
             _mcPkgApiService = new Mock<IMcPkgApiService>();
             _readOnlyContext = new Mock<IReadOnlyContext>();
             _applicationAuthenticator = new Mock<IApplicationAuthenticator>();
@@ -60,7 +58,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
                                           _unitOfWork.Object,
                                           _telemetryClient.Object,
                                           _readOnlyContext.Object,
-                                          _fusionMeetingClient.Object,
                                           _mcPkgApiService.Object,
                                           _applicationAuthenticator.Object,
                                           _bearerTokenSetter.Object);
@@ -126,7 +123,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _mcPkgApiService.Verify(m => m.SetM01DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.ClearM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.SetM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
-            _fusionMeetingClient.Verify(f => f.DeleteMeetingAsync(_invitation.MeetingId));
         }
 
         [TestMethod]
@@ -167,7 +163,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _mcPkgApiService.Verify(m => m.SetM01DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.ClearM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.SetM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
-            _fusionMeetingClient.Verify(f => f.DeleteMeetingAsync(_invitation.MeetingId), Times.Never);
         }
 
         [TestMethod]
@@ -188,7 +183,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _mcPkgApiService.Verify(m => m.SetM01DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Once);
             _mcPkgApiService.Verify(m => m.ClearM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.SetM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
-            _fusionMeetingClient.Verify(f => f.DeleteMeetingAsync(_invitation.MeetingId), Times.Never);
         }
 
         [TestMethod]
@@ -209,7 +203,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _mcPkgApiService.Verify(m => m.SetM01DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.ClearM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.SetM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Once);
-            _fusionMeetingClient.Verify(f => f.DeleteMeetingAsync(_invitation.MeetingId), Times.Never);
         }
 
         [TestMethod]
@@ -230,7 +223,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _mcPkgApiService.Verify(m => m.SetM01DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
             _mcPkgApiService.Verify(m => m.ClearM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Once);
             _mcPkgApiService.Verify(m => m.SetM02DatesAsync(plant, _invitation.Id, project, new List<string>(), new List<string>()), Times.Never);
-            _fusionMeetingClient.Verify(f => f.DeleteMeetingAsync(_invitation.MeetingId), Times.Never);
         }
 
         [TestMethod]


### PR DESCRIPTION
During refactoring. Cancel fusion meeting was accidentally moved to bus receive and call as sync user  instead of call as logged in user.