### PR TITLE
81918 Add indexes on properties used in filter

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210323093442_AddIndexes.Designer.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210323093442_AddIndexes.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.ProCoSys.IPO.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
 {
     [DbContext(typeof(IPOContext))]
-    partial class IPOContextModelSnapshot : ModelSnapshot
+    [Migration("20210323093442_AddIndexes")]
+    partial class AddIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210323093442_AddIndexes.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20210323093442_AddIndexes.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
+{
+    public partial class AddIndexes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_ProjectName",
+                table: "Invitations",
+                column: "ProjectName");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_Title",
+                table: "Invitations",
+                column: "Title");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_Status",
+                table: "Invitations",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CommPkgs_CommPkgNo",
+                table: "CommPkgs",
+                column: "CommPkgNo");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_McPkgs_McPkgNo",
+                table: "McPkgs",
+                column: "McPkgNo");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
[AB#81918](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81918)

Some searches (especially on Johan Castberg in prod) are so slow that we get exception. Possible problem is that we are missing index on some properties. ProjectName feks is always included, so this is perhaps the biggest problem.