### PR TITLE
81958 fixed signing bug + small rename

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
                 .Must(command => HaveAValidRowVersion(command.ParticipantRowVersion))
                 .WithMessage(command =>
                     $"Participant row version is not valid! ParticipantRowVersion={command.ParticipantRowVersion}")
-                .MustAsync((command, cancellationToken) => BeAConstructionCompanyOnIpo(command.InvitationId, cancellationToken))
+                .MustAsync((command, cancellationToken) => BeAnAccepterOnIpo(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "The IPO does not have a construction company assigned to accept the IPO!")
                 .MustAsync((command, cancellationToken) => BeTheAssignedPersonIfPersonParticipant(command.InvitationId, cancellationToken))
@@ -47,11 +47,11 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
             async Task<bool> BeAnInvitationInCompletedStage(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Completed, cancellationToken);
 
-            async Task<bool> BeAConstructionCompanyOnIpo(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ConstructionCompanyExistsAsync(invitationId, cancellationToken);
+            async Task<bool> BeAnAccepterOnIpo(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IpoHasAccepterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeTheAssignedPersonIfPersonParticipant(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidConstructionCompanyParticipantExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.ValidAccepterParticipantExistsAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
                 .Must(command => HaveAValidRowVersion(command.ParticipantRowVersion))
                 .WithMessage(command =>
                     $"Participant row version is not valid! ParticipantRowVersion={command.ParticipantRowVersion}")
-                .MustAsync((command, cancellationToken) => BeAContractorOnIpo(command.InvitationId, cancellationToken))
+                .MustAsync((command, cancellationToken) => BeACompleterOnIpo(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "The IPO does not have a contractor assigned to complete the IPO!")
                 .MustAsync((command, cancellationToken) => BeTheAssignedPersonIfPersonParticipant(command.InvitationId, cancellationToken))
@@ -47,11 +47,11 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
             async Task<bool> BeAnInvitationInPlannedStage(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Planned, cancellationToken);
 
-            async Task<bool> BeAContractorOnIpo(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ContractorExistsAsync(invitationId, cancellationToken);
+            async Task<bool> BeACompleterOnIpo(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IpoHasCompleterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeTheAssignedPersonIfPersonParticipant(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidContractorParticipantExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.ValidCompleterParticipantExistsAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidator.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut
                 .Must(command => HaveAValidRowVersion(command.ParticipantRowVersion))
                 .WithMessage(command =>
                     $"Participant row version is not valid! ParticipantRowVersion={command.ParticipantRowVersion}")
-                .MustAsync((command, cancellationToken) => BeAConstructionCompanyOnIpo(command.InvitationId, cancellationToken))
+                .MustAsync((command, cancellationToken) => BeAnAccepterOnIpo(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "The IPO does not have a construction company assigned to accept the IPO!")
                 .MustAsync((command, cancellationToken) => BeThePersonWhoAccepted(command.InvitationId, cancellationToken))
@@ -39,8 +39,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut
             async Task<bool> BeAnInvitationInAcceptedStage(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Accepted, cancellationToken);
 
-            async Task<bool> BeAConstructionCompanyOnIpo(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ConstructionCompanyExistsAsync(invitationId, cancellationToken);
+            async Task<bool> BeAnAccepterOnIpo(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IpoHasAccepterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeThePersonWhoAccepted(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.SameUserUnAcceptingThatAcceptedAsync(invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidator.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
                 .Must(command => HaveAValidRowVersion(command.ParticipantRowVersion))
                 .WithMessage(command =>
                     $"Participant row version is not valid! ParticipantRowVersion={command.ParticipantRowVersion}")
-                .MustAsync((command, cancellationToken) => BeAContractorOnIpo(command.InvitationId, cancellationToken))
+                .MustAsync((command, cancellationToken) => BeACompleterOnIpo(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "The IPO does not have a contractor assigned to uncomplete the IPO!")
                 .MustAsync((command, cancellationToken) => BeThePersonWhoCompleted(command.InvitationId, cancellationToken))
@@ -39,8 +39,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
             async Task<bool> BeAnInvitationInCompletedStage(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Completed, cancellationToken);
 
-            async Task<bool> BeAContractorOnIpo(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ContractorExistsAsync(invitationId, cancellationToken);
+            async Task<bool> BeACompleterOnIpo(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IpoHasCompleterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeThePersonWhoCompleted(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.SameUserUnCompletingThatCompletedAsync(invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
@@ -45,10 +45,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusAn
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
 
             async Task<bool> BeTheAssignedContractorIfPersonParticipant(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidContractorParticipantExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.ValidCompleterParticipantExistsAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAContractorOnIpo(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ContractorExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.IpoHasCompleterAsync(invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
@@ -18,10 +18,10 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
         Task<bool> AttachmentWithFileNameExistsAsync(int invitationId, string fileName, CancellationToken cancellationToken);
         Task<bool> IpoExistsAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> IpoIsInStageAsync(int invitationId, IpoStatus stage, CancellationToken cancellationToken);
-        Task<bool> ValidContractorParticipantExistsAsync(int invitationId, CancellationToken cancellationToken);
-        Task<bool> ValidConstructionCompanyParticipantExistsAsync(int invitationId, CancellationToken cancellationToken);
-        Task<bool> ContractorExistsAsync(int invitationId, CancellationToken cancellationToken);
-        Task<bool> ConstructionCompanyExistsAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> ValidCompleterParticipantExistsAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> ValidAccepterParticipantExistsAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> IpoHasCompleterAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> IpoHasAccepterAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SignerExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
         Task<bool> ValidSigningParticipantExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
         Task<bool> CurrentUserIsCreatorOfInvitation(int invitationId, CancellationToken cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
@@ -182,7 +182,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
             return true;
         }
 
-        public async Task<bool> ValidContractorParticipantExistsAsync(int invitationId, CancellationToken cancellationToken)
+        public async Task<bool> ValidCompleterParticipantExistsAsync(int invitationId, CancellationToken cancellationToken)
         {
             var participants = await(from participant in _context.QuerySet<Participant>()
                 where EF.Property<int>(participant, "InvitationId") == invitationId &&
@@ -203,7 +203,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
             return participants.Single().AzureOid == _currentUserProvider.GetCurrentUserOid();
         }
 
-        public async Task<bool> ValidConstructionCompanyParticipantExistsAsync(int invitationId, CancellationToken cancellationToken)
+        public async Task<bool> ValidAccepterParticipantExistsAsync(int invitationId, CancellationToken cancellationToken)
         {
             var participants = await (from participant in _context.QuerySet<Participant>()
                 where EF.Property<int>(participant, "InvitationId") == invitationId &&
@@ -225,14 +225,14 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
             return participants.First().AzureOid == _currentUserProvider.GetCurrentUserOid();
         }
 
-        public async Task<bool> ContractorExistsAsync(int invitationId, CancellationToken cancellationToken) =>
+        public async Task<bool> IpoHasCompleterAsync(int invitationId, CancellationToken cancellationToken) =>
             await (from participant in _context.QuerySet<Participant>()
                 where EF.Property<int>(participant, "InvitationId") == invitationId &&
                       participant.SortKey == 0 &&
                       participant.Organization == Organization.Contractor
                 select participant).AnyAsync(cancellationToken);
 
-        public async Task<bool> ConstructionCompanyExistsAsync(int invitationId, CancellationToken cancellationToken) =>
+        public async Task<bool> IpoHasAccepterAsync(int invitationId, CancellationToken cancellationToken) =>
             await (from participant in _context.QuerySet<Participant>()
                 where EF.Property<int>(participant, "InvitationId") == invitationId &&
                       participant.SortKey == 1 &&
@@ -245,7 +245,9 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
                       participant.Id == participantId &&
                       (participant.Organization == Organization.TechnicalIntegrity ||
                        participant.Organization == Organization.Operation ||
-                       participant.Organization == Organization.Commissioning)
+                       participant.Organization == Organization.Commissioning ||
+                       participant.Organization == Organization.Contractor ||
+                       participant.Organization == Organization.ConstructionCompany)
                 select participant).AnyAsync(cancellationToken);
 
         public async Task<bool> ValidSigningParticipantExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken)

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidatorTests.cs
@@ -48,8 +48,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion2)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Completed, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidConstructionCompanyParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ConstructionCompanyExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ValidAccepterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasAccepterAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId2, _id, default)).Returns(Task.FromResult(true));
             _command = new AcceptPunchOutCommand(
@@ -108,7 +108,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenInvitationDoesNotHaveConstructionCompanyParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ConstructionCompanyExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasAccepterAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
@@ -120,7 +120,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToAcceptIsNotAValidConstructionCompanyParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidConstructionCompanyParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.ValidAccepterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidatorTests.cs
@@ -51,8 +51,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion2)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Planned, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidContractorParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ContractorExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId2, _id, default)).Returns(Task.FromResult(true));
             _command = new CompletePunchOutCommand(
@@ -111,7 +111,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenInvitationDoesNotHaveContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ContractorExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
@@ -123,7 +123,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToCompleteIsNotAValidContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidContractorParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidatorTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnAcceptPunchOut
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Accepted, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.SameUserUnAcceptingThatAcceptedAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ConstructionCompanyExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasAccepterAsync(_id, default)).Returns(Task.FromResult(true));
             _command = new UnAcceptPunchOutCommand(
                 _id,
                 _invitationRowVersion,
@@ -86,7 +86,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnAcceptPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenInvitationDoesNotHaveConstructionCompanyParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ConstructionCompanyExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasAccepterAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidatorTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Completed, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.SameUserUnCompletingThatCompletedAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ContractorExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(true));
             _command = new UnCompletePunchOutCommand(
                 _id,
                 _invitationRowVersion,
@@ -86,7 +86,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
         [TestMethod]
         public void Validate_ShouldFail_WhenInvitationDoesNotHaveContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ContractorExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidatorTests.cs
@@ -48,8 +48,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion2)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Completed, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidContractorParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ContractorExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId2, _id, default)).Returns(Task.FromResult(true));
             _command = new UpdateAttendedStatusAndNotesOnParticipantsCommand(
@@ -118,7 +118,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
         [TestMethod]
         public void Validate_ShouldFail_WhenInvitationDoesNotHaveContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ContractorExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
@@ -130,7 +130,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToCompleteIsNotAValidContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidContractorParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -937,121 +937,121 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ValidConstructionCompanyParticipantExistsAsync_FunctionalRoleAsConstructionCompany_ReturnsTrue()
+        public async Task ValidAccepterParticipantExistsAsync_FunctionalRoleAsAccepter_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ValidConstructionCompanyParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidConstructionCompanyParticipantExistsAsync_PersonAsConstructionCompany_ReturnsTrue()
+        public async Task ValidAccepterParticipantExistsAsync_PersonAsAccepter_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ValidConstructionCompanyParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidConstructionCompanyParticipantExistsAsync_ConstructionCompanyPersonIsntCurrentUser_ReturnsFalse()
+        public async Task ValidAccepterParticipantExistsAsync_AccepterPersonIsntCurrentUser_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ValidConstructionCompanyParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ConstructionCompanyExistsAsync_ConstructionCompanyExists_ReturnsTrue()
+        public async Task IpoHasAccepterAsync_AccepterExists_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ConstructionCompanyExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.IpoHasAccepterAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ConstructionCompanyExistsAsync_ConstructionCompanyDoesntExists_ReturnsFalse()
+        public async Task IpoHasAccepterAsync_AccepterDoesntExists_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ConstructionCompanyExistsAsync(_invitationIdWithoutParticipants, default);
+                var result = await dut.IpoHasAccepterAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidContractorParticipantExistsAsync_FunctionalRoleAsContractor_ReturnsTrue()
+        public async Task ValidCompleterParticipantExistsAsyncAsync_FunctionalRoleAsCompleter_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ValidContractorParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidContractorParticipantExistsAsync_PersonAsContractor_ReturnsTrue()
+        public async Task ValidCompleterParticipantExistsAsync_PersonAsCompleter_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ValidContractorParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidContractorParticipantExistsAsync_ContractorPersonIsntCurrentUser_ReturnsFalse()
+        public async Task ValidCompleterParticipantExistsAsync_CompleterPersonIsntCurrentUser_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ValidContractorParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ContractorExistsAsync_ContractorExists_ReturnsTrue()
+        public async Task IpoHasCompleterAsync_CompleterExists_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ContractorExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.IpoHasCompleterAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ContractorExistsAsync_ContractorDoesntExists_ReturnsFalse()
+        public async Task IpoHasCompleterAsync_CompleterDoesntExists_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.ContractorExistsAsync(_invitationIdWithoutParticipants, default);
+                var result = await dut.IpoHasCompleterAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsFalse(result);
             }
         }


### PR DESCRIPTION
[AB#81958](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81958)

Fixed signing bug where contractor and construction company could not perform regular sign. This functionality was wanted from last week, but forgot to change business validator - fixed now.

Small rename. Not "ContractorExists" for example when checking if Completer exists (even if it is a contractor)