### PR TITLE
80593 to do list end point for main

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandler.cs
@@ -18,7 +18,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly IPersonRepository _personRepository;
 
         public AcceptPunchOutCommandHandler(
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             ICurrentUserProvider currentUserProvider, 
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             IPersonRepository personRepository)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandler.cs
@@ -18,7 +18,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly IPersonRepository _personRepository;
 
         public CompletePunchOutCommandHandler(
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             ICurrentUserProvider currentUserProvider, 
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             IPersonRepository personRepository)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         private readonly IFusionMeetingClient _meetingClient;
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
-        private readonly ICommPkgApiService _commPkgApiService;
+        private readonly IMainCommPkgApiService _commPkgApiService;
         private readonly IMcPkgApiService _mcPkgApiService;
         private readonly IPersonApiService _personApiService;
         private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
@@ -40,7 +40,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             IFusionMeetingClient meetingClient,
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
-            ICommPkgApiService commPkgApiService,
+            IMainCommPkgApiService commPkgApiService,
             IMcPkgApiService mcPkgApiService,
             IPersonApiService personApiService,
             ILibraryFunctionalRoleApiService functionalRoleApiService,

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMainCommPkgApiService _commPkgApiService;
-        private readonly IMcPkgApiService _mcPkgApiService;
+        private readonly IMainMcPkgApiService _mcPkgApiService;
         private readonly IPersonApiService _personApiService;
         private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IOptionsMonitor<MeetingOptions> _meetingOptions;
@@ -41,7 +41,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             IMainCommPkgApiService commPkgApiService,
-            IMcPkgApiService mcPkgApiService,
+            IMainMcPkgApiService mcPkgApiService,
             IPersonApiService personApiService,
             ILibraryFunctionalRoleApiService functionalRoleApiService,
             IOptionsMonitor<MeetingOptions> meetingOptions,

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMainCommPkgApiService _commPkgApiService;
         private readonly IMainMcPkgApiService _mcPkgApiService;
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IOptionsMonitor<MeetingOptions> _meetingOptions;
         private readonly IPersonRepository _personRepository;
@@ -42,7 +42,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             IUnitOfWork unitOfWork,
             IMainCommPkgApiService commPkgApiService,
             IMainMcPkgApiService mcPkgApiService,
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             ILibraryFunctionalRoleApiService functionalRoleApiService,
             IOptionsMonitor<MeetingOptions> meetingOptions,
             IPersonRepository personRepository,

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         private readonly ICommPkgApiService _commPkgApiService;
         private readonly IMcPkgApiService _mcPkgApiService;
         private readonly IPersonApiService _personApiService;
-        private readonly IFunctionalRoleApiService _functionalRoleApiService;
+        private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IOptionsMonitor<MeetingOptions> _meetingOptions;
         private readonly IPersonRepository _personRepository;
         private readonly ICurrentUserProvider _currentUserProvider;
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             ICommPkgApiService commPkgApiService,
             IMcPkgApiService mcPkgApiService,
             IPersonApiService personApiService,
-            IFunctionalRoleApiService functionalRoleApiService,
+            ILibraryFunctionalRoleApiService functionalRoleApiService,
             IOptionsMonitor<MeetingOptions> meetingOptions,
             IPersonRepository personRepository,
             ICurrentUserProvider currentUserProvider)

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         private readonly IPlantProvider _plantProvider;
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMcPkgApiService _mcPkgApiService;
-        private readonly ICommPkgApiService _commPkgApiService;
+        private readonly IMainCommPkgApiService _commPkgApiService;
         private readonly IPersonApiService _personApiService;
         private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IOptionsMonitor<MeetingOptions> _meetingOptions;
@@ -41,7 +41,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
             IPlantProvider plantProvider,
             IUnitOfWork unitOfWork,
             IMcPkgApiService mcPkgApiService,
-            ICommPkgApiService commPkgApiService,
+            IMainCommPkgApiService commPkgApiService,
             IPersonApiService personApiService,
             ILibraryFunctionalRoleApiService functionalRoleApiService,
             IOptionsMonitor<MeetingOptions> meetingOptions,

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -31,7 +31,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         private readonly IMcPkgApiService _mcPkgApiService;
         private readonly ICommPkgApiService _commPkgApiService;
         private readonly IPersonApiService _personApiService;
-        private readonly IFunctionalRoleApiService _functionalRoleApiService;
+        private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IOptionsMonitor<MeetingOptions> _meetingOptions;
         private readonly IPersonRepository _personRepository;
 
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
             IMcPkgApiService mcPkgApiService,
             ICommPkgApiService commPkgApiService,
             IPersonApiService personApiService,
-            IFunctionalRoleApiService functionalRoleApiService,
+            ILibraryFunctionalRoleApiService functionalRoleApiService,
             IOptionsMonitor<MeetingOptions> meetingOptions,
             IPersonRepository personRepository)
         {

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         private readonly IFusionMeetingClient _meetingClient;
         private readonly IPlantProvider _plantProvider;
         private readonly IUnitOfWork _unitOfWork;
-        private readonly IMcPkgApiService _mcPkgApiService;
+        private readonly IMainMcPkgApiService _mcPkgApiService;
         private readonly IMainCommPkgApiService _commPkgApiService;
         private readonly IPersonApiService _personApiService;
         private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
@@ -40,7 +40,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
             IFusionMeetingClient meetingClient,
             IPlantProvider plantProvider,
             IUnitOfWork unitOfWork,
-            IMcPkgApiService mcPkgApiService,
+            IMainMcPkgApiService mcPkgApiService,
             IMainCommPkgApiService commPkgApiService,
             IPersonApiService personApiService,
             ILibraryFunctionalRoleApiService functionalRoleApiService,

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMainMcPkgApiService _mcPkgApiService;
         private readonly IMainCommPkgApiService _commPkgApiService;
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IOptionsMonitor<MeetingOptions> _meetingOptions;
         private readonly IPersonRepository _personRepository;
@@ -42,7 +42,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
             IUnitOfWork unitOfWork,
             IMainMcPkgApiService mcPkgApiService,
             IMainCommPkgApiService commPkgApiService,
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             ILibraryFunctionalRoleApiService functionalRoleApiService,
             IOptionsMonitor<MeetingOptions> meetingOptions,
             IPersonRepository personRepository)

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandHandler.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly IPersonRepository _personRepository;
 
         public SignPunchOutCommandHandler(
@@ -24,7 +24,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             ICurrentUserProvider currentUserProvider, 
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             IPersonRepository personRepository)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandler.cs
@@ -16,14 +16,14 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IMcPkgApiService _mcPkgApiService;
+        private readonly IMainMcPkgApiService _mcPkgApiService;
 
         public UnCompletePunchOutCommandHandler(
             IPlantProvider plantProvider,
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             ICurrentUserProvider currentUserProvider, 
-            IMcPkgApiService mcPkgApiService)
+            IMainMcPkgApiService mcPkgApiService)
         {
             _plantProvider = plantProvider;
             _invitationRepository = invitationRepository;

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandler.cs
@@ -16,14 +16,14 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusAn
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
 
         public UpdateAttendedStatusAndNotesOnParticipantsCommandHandler(
             IPlantProvider plantProvider,
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             ICurrentUserProvider currentUserProvider, 
-            IPersonApiService personApiService)
+            IMainPersonApiService personApiService)
         {
             _plantProvider = plantProvider;
             _invitationRepository = invitationRepository;

--- a/src/Equinor.ProCoSys.IPO.Command/PersonCommands/CreateSavedFilter/CreateSavedFilterCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/PersonCommands/CreateSavedFilter/CreateSavedFilterCommandHandler.cs
@@ -15,14 +15,14 @@ namespace Equinor.ProCoSys.IPO.Command.PersonCommands.CreateSavedFilter
         private readonly IUnitOfWork _unitOfWork;
         private readonly IPlantProvider _plantProvider;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IProjectApiService _projectApiService;
+        private readonly IMainProjectApiService _projectApiService;
 
         public CreateSavedFilterCommandHandler(
             IPersonRepository personRepository,
             IUnitOfWork unitOfWork,
             IPlantProvider plantProvider,
             ICurrentUserProvider currentUserProvider,
-            IProjectApiService projectApiService)
+            IMainProjectApiService projectApiService)
         {
             _personRepository = personRepository;
             _unitOfWork = unitOfWork;

--- a/src/Equinor.ProCoSys.IPO.MainApi/LibraryApi/FunctionalRole/ILibraryFunctionalRoleApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/LibraryApi/FunctionalRole/ILibraryFunctionalRoleApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.LibraryApi.FunctionalRole
 {
-    public interface IFunctionalRoleApiService
+    public interface ILibraryFunctionalRoleApiService
     {
         Task<IList<ProCoSysFunctionalRole>> GetFunctionalRolesByClassificationAsync(string plant, string classification);
         Task<IList<ProCoSysFunctionalRole>> GetFunctionalRolesByCodeAsync(string plant, List<string> functionalRoleCodes);

--- a/src/Equinor.ProCoSys.IPO.MainApi/LibraryApi/FunctionalRole/LibraryApiFunctionalRoleService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/LibraryApi/FunctionalRole/LibraryApiFunctionalRoleService.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.LibraryApi.FunctionalRole
 {
-    public class LibraryApiFunctionalRoleService : IFunctionalRoleApiService
+    public class LibraryApiFunctionalRoleService : ILibraryFunctionalRoleApiService
     {
         private readonly IBearerTokenApiClient _foreignApiClient;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/IMainCommPkgApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/IMainCommPkgApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg
 {
-    public interface ICommPkgApiService
+    public interface IMainCommPkgApiService
     {
         Task<ProCoSysCommPkgSearchResult> SearchCommPkgsByCommPkgNoAsync(string plant, string projectName, string startsWithCommPkgNo, int? itemsPerPage = 10, int? currentPage = 0);
         Task<IList<ProCoSysCommPkg>> GetCommPkgsByCommPkgNosAsync(string plant, string projectName, IList<string> commPkgNos);

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/MainApiCommPkgService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/MainApiCommPkgService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg
 {
-    public class MainApiCommPkgService : ICommPkgApiService
+    public class MainApiCommPkgService : IMainCommPkgApiService
     {
         private readonly IBearerTokenApiClient _foreignApiClient;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/IFunctionalRoleApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/IFunctionalRoleApiService.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole
+{
+    public interface IFunctionalRoleApiService
+    {
+        Task<IList<string>> GetFunctionalRoleCodesByPersonOidAsync(string plant, string azureOid);
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/IMainFunctionalRoleApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/IMainFunctionalRoleApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole
 {
-    public interface IFunctionalRoleApiService
+    public interface IMainFunctionalRoleApiService
     {
         Task<IList<string>> GetFunctionalRoleCodesByPersonOidAsync(string plant, string azureOid);
     }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/MainApiFunctionalRoleService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/MainApiFunctionalRoleService.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole
 {
-    public class MainApiFunctionalRoleService : IFunctionalRoleApiService
+    public class MainApiFunctionalRoleService : IMainFunctionalRoleApiService
     {
         private readonly IBearerTokenApiClient _foreignApiClient;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/MainApiFunctionalRoleService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/MainApiFunctionalRoleService.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.ForeignApi.Client;
+using Microsoft.Extensions.Options;
+
+namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole
+{
+    public class MainApiFunctionalRoleService : IFunctionalRoleApiService
+    {
+        private readonly IBearerTokenApiClient _foreignApiClient;
+        private readonly Uri _baseAddress;
+        private readonly string _apiVersion;
+
+        public MainApiFunctionalRoleService(
+            IBearerTokenApiClient foreignApiClient,
+            IOptionsMonitor<MainApiOptions> options)
+        {
+            _foreignApiClient = foreignApiClient;
+            _baseAddress = new Uri(options.CurrentValue.BaseAddress);
+            _apiVersion = options.CurrentValue.ApiVersion;
+        }
+
+        public async Task<IList<string>> GetFunctionalRoleCodesByPersonOidAsync(
+            string plant,
+            string azureOid)
+        {
+            var url = $"{_baseAddress}/Library/FunctionalRoleCodesByPersonOid" +
+                      $"?plantId={plant}" +
+                      $"&personOid={WebUtility.UrlEncode(azureOid)}" +
+                      $"&api-version={_apiVersion}";
+
+            var result = await _foreignApiClient.QueryAndDeserializeAsync<List<ProCoSysFunctionalRoleCode>>(url);
+            return result.Select(r => r.Code).ToList();
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/ProCoSysFunctionalRoleCode.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/FunctionalRole/ProCoSysFunctionalRoleCode.cs
@@ -1,0 +1,7 @@
+﻿namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole
+{
+    public class ProCoSysFunctionalRoleCode
+    {
+        public string Code { get; set; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/IMainMcPkgApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/IMainMcPkgApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg
 {
-    public interface IMcPkgApiService
+    public interface IMainMcPkgApiService
     {
         Task<IList<ProCoSysMcPkg>> GetMcPkgsByCommPkgNoAndProjectNameAsync(string plant, string projectName, string commPkgNo);
         Task<IList<ProCoSysMcPkg>> GetMcPkgsByMcPkgNosAsync(string plant, string projectName, IList<string> mcPkgNos);

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/MainApiMcPkgService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/MainApiMcPkgService.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg
 {
-    public class MainApiMcPkgService : IMcPkgApiService
+    public class MainApiMcPkgService : IMainMcPkgApiService
     {
         private readonly IBearerTokenApiClient _foreignApiClient;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Permission/IMainPermissionApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Permission/IMainPermissionApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Permission
 {
-    public interface IPermissionApiService
+    public interface IMainPermissionApiService
     {
         Task<IList<string>> GetPermissionsAsync(string plantId);
         Task<IList<ProCoSysProject>> GetAllOpenProjectsAsync(string plantId);

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Permission/MainApiPermissionService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Permission/MainApiPermissionService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Permission
 {
-    public class MainApiPermissionService : IPermissionApiService
+    public class MainApiPermissionService : IMainPermissionApiService
     {
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Person/IMainPersonApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Person/IMainPersonApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person
 {
-    public interface IPersonApiService
+    public interface IMainPersonApiService
     {
         Task<IList<ProCoSysPerson>> GetPersonsAsync(string plant, string searchString, long numberOfRows = 1000);
         Task<IList<ProCoSysPerson>> GetPersonsWithPrivilegesAsync(string plant, string searchString, string objectName, IList<string> privileges);

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Person/MainApiPersonService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Person/MainApiPersonService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person
 {
-    public class MainApiPersonService : IPersonApiService
+    public class MainApiPersonService : IMainPersonApiService
     {
         private readonly IBearerTokenApiClient _foreignApiClient;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Plant/IMainPlantApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Plant/IMainPlantApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Plant
 {
-    public interface IPlantApiService
+    public interface IMainPlantApiService
     {
         Task<List<ProCoSysPlant>> GetAllPlantsAsync();
     }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Plant/MainApiPlantService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Plant/MainApiPlantService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Plant
 {
-    public class MainApiPlantService : IPlantApiService
+    public class MainApiPlantService : IMainPlantApiService
     {
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/IMainProjectApiService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/IMainProjectApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Project
 {
-    public interface IProjectApiService
+    public interface IMainProjectApiService
     {
         Task<ProCoSysProject> TryGetProjectAsync(string plant, string name);
         Task<IList<ProCoSysProject>> GetProjectsInPlantAsync(string plant);

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/MainApiProjectService.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/Project/MainApiProjectService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.Project
 {
-    public class MainApiProjectService : IProjectApiService
+    public class MainApiProjectService : IMainProjectApiService
     {
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;

--- a/src/Equinor.ProCoSys.IPO.Query/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandler.cs
@@ -11,11 +11,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetCommPkgsInProject
 {
     public class GetCommPkgsInProjectQueryHandler : IRequestHandler<GetCommPkgsInProjectQuery, Result<ProCoSysCommPkgSearchDto>>
     {
-        private readonly ICommPkgApiService _commPkgApiService;
+        private readonly IMainCommPkgApiService _commPkgApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetCommPkgsInProjectQueryHandler(
-            ICommPkgApiService commPkgApiService,
+            IMainCommPkgApiService commPkgApiService,
             IPlantProvider plantProvider)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Query/GetFunctionalRoles/GetFunctionalRolesForIpoQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetFunctionalRoles/GetFunctionalRolesForIpoQueryHandler.cs
@@ -11,11 +11,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetFunctionalRoles
 {
     public class GetFunctionalRolesForIpoQueryHandler : IRequestHandler<GetFunctionalRolesForIpoQuery, Result<List<ProCoSysFunctionalRoleDto>>>
     {
-        private readonly IFunctionalRoleApiService _functionalRoleApiService;
+        private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetFunctionalRolesForIpoQueryHandler(
-            IFunctionalRoleApiService functionalRoleApiService,
+            ILibraryFunctionalRoleApiService functionalRoleApiService,
             IPlantProvider plantProvider)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -21,7 +21,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         private readonly IReadOnlyContext _context;
         private readonly IFusionMeetingClient _meetingClient;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IFunctionalRoleApiService _functionalRoleApiService;
+        private readonly ILibraryFunctionalRoleApiService _functionalRoleApiService;
         private readonly IPlantProvider _plantProvider;
         private readonly ILogger<GetInvitationByIdQueryHandler> _logger;
 
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             IReadOnlyContext context,
             IFusionMeetingClient meetingClient,
             ICurrentUserProvider currentUserProvider,
-            IFunctionalRoleApiService functionalRoleApiService,
+            ILibraryFunctionalRoleApiService functionalRoleApiService,
             IPlantProvider plantProvider,
             ILogger<GetInvitationByIdQueryHandler> logger)
         {

--- a/src/Equinor.ProCoSys.IPO.Query/GetMcPkgsUnderCommPkgInProject/GetMcPkgsUnderCommPkgInProjectQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetMcPkgsUnderCommPkgInProject/GetMcPkgsUnderCommPkgInProjectQueryHandler.cs
@@ -11,11 +11,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetMcPkgsUnderCommPkgInProject
 {
     public class GetMcPkgsUnderCommPkgInProjectQueryHandler : IRequestHandler<GetMcPkgsUnderCommPkgInProjectQuery, Result<List<ProCoSysMcPkgDto>>>
     {
-        private readonly IMcPkgApiService _mcPkgApiService;
+        private readonly IMainMcPkgApiService _mcPkgApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetMcPkgsUnderCommPkgInProjectQueryHandler(
-            IMcPkgApiService mcPkgApiService,
+            IMainMcPkgApiService mcPkgApiService,
             IPlantProvider plantProvider)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQuery.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQuery.cs
@@ -1,0 +1,13 @@
+﻿using Equinor.ProCoSys.IPO.Domain;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIpos
+{
+    public class GetOutstandingIposQuery : IRequest<Result<OutstandingIposResultDto>>, IProjectRequest
+    {
+        public GetOutstandingIposQuery(string projectName) => ProjectName = projectName;
+
+        public string ProjectName { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQueryHandler.cs
@@ -65,18 +65,21 @@ namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIPOs
                     InvitationId = invitation.Id,
                     Description = invitation.Description
                 }));
+
             return new SuccessResult<OutstandingIposResultDto>(outstandingIposResultDto);
         }
 
-        private static bool UserWasInvitedAsPersonParticipant(Invitation invitation, Guid currentUserOid) => invitation.Participants.Any(p => p.AzureOid == currentUserOid);
+        private static bool UserWasInvitedAsPersonParticipant(Invitation invitation, Guid currentUserOid) 
+            => invitation.Participants.Any(p => p.AzureOid == currentUserOid);
 
-        private static bool UserWasInvitedAsPersonInFunctionalRole(Invitation invitation, IList<string> currentUsersFunctionalRoleCodes)
+        private static bool UserWasInvitedAsPersonInFunctionalRole(Invitation invitation, IEnumerable<string> currentUsersFunctionalRoleCodes)
         {
             var functionalRoleParticipantCodesOnInvitation = invitation.Participants.Where(p => p.SortKey == 1 &&
                                                p.FunctionalRoleCode != null &&
                                                p.Type == IpoParticipantType.FunctionalRole).Select(p => p.FunctionalRoleCode).ToList();
 
-            return currentUsersFunctionalRoleCodes.Select(functionalRoleCode => functionalRoleParticipantCodesOnInvitation.Contains(functionalRoleCode)).FirstOrDefault();
+            return currentUsersFunctionalRoleCodes.Select(functionalRoleCode 
+                => functionalRoleParticipantCodesOnInvitation.Contains(functionalRoleCode)).FirstOrDefault();
         }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQueryHandler.cs
@@ -17,13 +17,13 @@ namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIPOs
     {
         private readonly IReadOnlyContext _context;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IFunctionalRoleApiService _functionalRoleApiService;
+        private readonly IMainFunctionalRoleApiService _functionalRoleApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetOutstandingIposQueryHandler(
             IReadOnlyContext context,
             ICurrentUserProvider currentUserProvider,
-            IFunctionalRoleApiService functionalRoleApiService,
+            IMainFunctionalRoleApiService functionalRoleApiService,
             IPlantProvider plantProvider)
         {
             _context = context;

--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposQueryHandler.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole;
+using Equinor.ProCoSys.IPO.Query.GetOutstandingIpos;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIPOs
+{
+    public class GetOutstandingIposQueryHandler : IRequestHandler<GetOutstandingIposQuery, Result<OutstandingIposResultDto>>
+    {
+        private readonly IReadOnlyContext _context;
+        private readonly ICurrentUserProvider _currentUserProvider;
+        private readonly IFunctionalRoleApiService _functionalRoleApiService;
+        private readonly IPlantProvider _plantProvider;
+
+        public GetOutstandingIposQueryHandler(
+            IReadOnlyContext context,
+            ICurrentUserProvider currentUserProvider,
+            IFunctionalRoleApiService functionalRoleApiService,
+            IPlantProvider plantProvider)
+        {
+            _context = context;
+            _currentUserProvider = currentUserProvider;
+            _functionalRoleApiService = functionalRoleApiService;
+            _plantProvider = plantProvider;
+        }
+
+        public async Task<Result<OutstandingIposResultDto>> Handle(GetOutstandingIposQuery request,
+            CancellationToken cancellationToken)
+        {
+            var currentUserOid = _currentUserProvider.GetCurrentUserOid();
+
+            var currentUsersFunctionalRoleCodes =
+                await _functionalRoleApiService.GetFunctionalRoleCodesByPersonOidAsync(_plantProvider.Plant,
+                    currentUserOid.ToString());
+
+            var completedInvitations = await (from i in _context.QuerySet<Invitation>()
+                    .Include(ss => ss.Participants)
+                where i.CompletedAtUtc.HasValue
+                select i).ToListAsync(cancellationToken);
+
+            var currentUsersOutstandingInvitations = new List<Invitation>();
+            foreach (var invitation in completedInvitations)
+            {
+                if (UserWasInvitedAsPersonParticipant(invitation, currentUserOid))
+                {
+                    currentUsersOutstandingInvitations.Add(invitation);
+                }
+                else if(UserWasInvitedAsPersonInFunctionalRole(invitation, currentUsersFunctionalRoleCodes))
+                {
+                    currentUsersOutstandingInvitations.Add(invitation);
+                }
+            }
+
+            var outstandingIposResultDto = new OutstandingIposResultDto(currentUsersOutstandingInvitations.Count,
+                currentUsersOutstandingInvitations.Select(invitation => new OutstandingIpoDetailsDto
+                {
+                    InvitationId = invitation.Id,
+                    Description = invitation.Description
+                }));
+            return new SuccessResult<OutstandingIposResultDto>(outstandingIposResultDto);
+        }
+
+        private static bool UserWasInvitedAsPersonParticipant(Invitation invitation, Guid currentUserOid) => invitation.Participants.Any(p => p.AzureOid == currentUserOid);
+
+        private static bool UserWasInvitedAsPersonInFunctionalRole(Invitation invitation, IList<string> currentUsersFunctionalRoleCodes)
+        {
+            var functionalRoleParticipantCodesOnInvitation = invitation.Participants.Where(p => p.SortKey == 1 &&
+                                               p.FunctionalRoleCode != null &&
+                                               p.Type == IpoParticipantType.FunctionalRole).Select(p => p.FunctionalRoleCode).ToList();
+
+            return currentUsersFunctionalRoleCodes.Select(functionalRoleCode => functionalRoleParticipantCodesOnInvitation.Contains(functionalRoleCode)).FirstOrDefault();
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/OutstandingIpoDetailsDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/OutstandingIpoDetailsDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIpos
+{
+    public class OutstandingIpoDetailsDto
+    {
+        public int InvitationId { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/OutstandingIposResultDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/OutstandingIposResultDto.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIpos
+{
+    public class OutstandingIposResultDto
+    {
+        public OutstandingIposResultDto(
+            int maxAvailable,
+            IEnumerable<OutstandingIpoDetailsDto> items)
+        {
+            MaxAvailable = maxAvailable;
+            Items = items;
+        }
+        public int MaxAvailable { get; }
+
+        public IEnumerable<OutstandingIpoDetailsDto> Items { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetPersons/GetPersonsQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetPersons/GetPersonsQueryHandler.cs
@@ -12,11 +12,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetPersons
 {
     public class GetPersonsQueryHandler : IRequestHandler<GetPersonsQuery, Result<List<ProCoSysPersonDto>>>
     {
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetPersonsQueryHandler(
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             IPlantProvider plantProvider)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Query/GetPersonsWithPrivileges/GetPersonsWithPrivilegesQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetPersonsWithPrivileges/GetPersonsWithPrivilegesQueryHandler.cs
@@ -13,11 +13,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetPersonsWithPrivileges
 {
     public class GetPersonsWithPrivilegesQueryHandler : IRequestHandler<GetPersonsWithPrivilegesQuery, Result<List<ProCoSysPersonDto>>>
     {
-        private readonly IPersonApiService _personApiService;
+        private readonly IMainPersonApiService _personApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetPersonsWithPrivilegesQueryHandler(
-            IPersonApiService personApiService,
+            IMainPersonApiService personApiService,
             IPlantProvider plantProvider)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.Query/GetProjectsInPlant/GetProjectsInPlantQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetProjectsInPlant/GetProjectsInPlantQueryHandler.cs
@@ -11,11 +11,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetProjectsInPlant
 {
     public class GetProjectsInPlantQueryHandler : IRequestHandler<GetProjectsInPlantQuery, Result<List<ProCoSysProjectDto>>>
     {
-        private readonly IProjectApiService _projectApiService;
+        private readonly IMainProjectApiService _projectApiService;
         private readonly IPlantProvider _plantProvider;
 
         public GetProjectsInPlantQueryHandler(
-            IProjectApiService projectApiService,
+            IMainProjectApiService projectApiService,
             IPlantProvider plantProvider)
         {
             _plantProvider = plantProvider;

--- a/src/Equinor.ProCoSys.IPO.WebApi/Caches/PermissionCache.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Caches/PermissionCache.cs
@@ -12,12 +12,12 @@ namespace Equinor.ProCoSys.IPO.WebApi.Caches
     public class PermissionCache : IPermissionCache
     {
         private readonly ICacheManager _cacheManager;
-        private readonly IPermissionApiService _permissionApiService;
+        private readonly IMainPermissionApiService _permissionApiService;
         private readonly IOptionsMonitor<CacheOptions> _options;
 
         public PermissionCache(
             ICacheManager cacheManager,
-            IPermissionApiService permissionApiService,
+            IMainPermissionApiService permissionApiService,
             IOptionsMonitor<CacheOptions> options)
         {
             _cacheManager = cacheManager;

--- a/src/Equinor.ProCoSys.IPO.WebApi/Caches/PlantCache.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Caches/PlantCache.cs
@@ -13,13 +13,13 @@ namespace Equinor.ProCoSys.IPO.WebApi.Caches
     {
         private readonly ICacheManager _cacheManager;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPlantApiService _plantApiService;
+        private readonly IMainPlantApiService _plantApiService;
         private readonly IOptionsMonitor<CacheOptions> _options;
 
         public PlantCache(
             ICacheManager cacheManager, 
             ICurrentUserProvider currentUserProvider, 
-            IPlantApiService plantApiService, 
+            IMainPlantApiService plantApiService, 
             IOptionsMonitor<CacheOptions> options)
         {
             _cacheManager = cacheManager;

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Misc/CacheController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Misc/CacheController.cs
@@ -17,9 +17,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Misc
         private readonly IPlantCache _plantCache;
         private readonly IPermissionCache _permissionCache;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPermissionApiService _permissionApiService;
+        private readonly IMainPermissionApiService _permissionApiService;
 
-        public CacheController(IPlantCache plantCache, IPermissionCache permissionCache, ICurrentUserProvider currentUserProvider, IPermissionApiService permissionApiService)
+        public CacheController(IPlantCache plantCache, IPermissionCache permissionCache, ICurrentUserProvider currentUserProvider, IMainPermissionApiService permissionApiService)
         {
             _plantCache = plantCache;
             _permissionCache = permissionCache;

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Persons/PersonsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Persons/PersonsController.cs
@@ -5,6 +5,7 @@ using Equinor.ProCoSys.IPO.Command.PersonCommands.CreateSavedFilter;
 using Equinor.ProCoSys.IPO.Query.GetSavedFiltersInProject;
 using Equinor.ProCoSys.IPO.Command.PersonCommands.UpdateSavedFilter;
 using Equinor.ProCoSys.IPO.Command.PersonCommands.DeleteSavedFilter;
+using Equinor.ProCoSys.IPO.Query.GetOutstandingIpos;
 using Equinor.ProCoSys.IPO.WebApi.Middleware;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -75,6 +76,18 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Persons
             [FromBody] DeleteSavedFilterDto dto)
         {
             var result = await _mediator.Send(new DeleteSavedFilterCommand(id, dto.RowVersion));
+            return this.FromResult(result);
+        }
+
+        [Authorize(Roles = Permissions.IPO_READ)]
+        [HttpGet("OutstandingIpos")]
+        public async Task<ActionResult<OutstandingIposResultDto>> GetOutstandingIpos(
+            [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
+            [Required]
+            string plant,
+            [FromQuery] string projectName)
+        {
+            var result = await _mediator.Send(new GetOutstandingIposQuery(projectName));
             return this.FromResult(result);
         }
     }

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -103,7 +103,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IBlobStorage, AzureBlobService>();
             services.AddScoped<ICommPkgApiService, MainApiCommPkgService>();
             services.AddScoped<IMcPkgApiService, MainApiMcPkgService>();
-            services.AddScoped<ForeignApi.LibraryApi.FunctionalRole.IFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
+            services.AddScoped<ILibraryFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
             services.AddScoped<IPersonApiService, MainApiPersonService>();
             services.AddScoped<ForeignApi.MainApi.FunctionalRole.IFunctionalRoleApiService, MainApiFunctionalRoleService>();
 

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -99,7 +99,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IBearerTokenApiClient, BearerTokenApiClient>();
             services.AddScoped<IPlantApiService, MainApiPlantService>();
             services.AddScoped<IProjectApiService, MainApiProjectService>();
-            services.AddScoped<IPermissionApiService, MainApiPermissionService>();
+            services.AddScoped<IMainPermissionApiService, MainApiPermissionService>();
             services.AddScoped<IBlobStorage, AzureBlobService>();
             services.AddScoped<IMainCommPkgApiService, MainApiCommPkgService>();
             services.AddScoped<IMainMcPkgApiService, MainApiMcPkgService>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -105,7 +105,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IMcPkgApiService, MainApiMcPkgService>();
             services.AddScoped<ILibraryFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
             services.AddScoped<IPersonApiService, MainApiPersonService>();
-            services.AddScoped<ForeignApi.MainApi.FunctionalRole.IFunctionalRoleApiService, MainApiFunctionalRoleService>();
+            services.AddScoped<IMainFunctionalRoleApiService, MainApiFunctionalRoleService>();
 
             services.AddScoped<IInvitationValidator, InvitationValidator>();
             services.AddScoped<IRowVersionValidator, RowVersionValidator>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -101,7 +101,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IProjectApiService, MainApiProjectService>();
             services.AddScoped<IPermissionApiService, MainApiPermissionService>();
             services.AddScoped<IBlobStorage, AzureBlobService>();
-            services.AddScoped<ICommPkgApiService, MainApiCommPkgService>();
+            services.AddScoped<IMainCommPkgApiService, MainApiCommPkgService>();
             services.AddScoped<IMcPkgApiService, MainApiMcPkgService>();
             services.AddScoped<ILibraryFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
             services.AddScoped<IPersonApiService, MainApiPersonService>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -97,7 +97,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IBearerTokenSetter>(x => x.GetRequiredService<Authenticator>());
             services.AddScoped<IApplicationAuthenticator>(x => x.GetRequiredService<Authenticator>());
             services.AddScoped<IBearerTokenApiClient, BearerTokenApiClient>();
-            services.AddScoped<IPlantApiService, MainApiPlantService>();
+            services.AddScoped<IMainPlantApiService, MainApiPlantService>();
             services.AddScoped<IProjectApiService, MainApiProjectService>();
             services.AddScoped<IMainPermissionApiService, MainApiPermissionService>();
             services.AddScoped<IBlobStorage, AzureBlobService>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -98,7 +98,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IApplicationAuthenticator>(x => x.GetRequiredService<Authenticator>());
             services.AddScoped<IBearerTokenApiClient, BearerTokenApiClient>();
             services.AddScoped<IMainPlantApiService, MainApiPlantService>();
-            services.AddScoped<IProjectApiService, MainApiProjectService>();
+            services.AddScoped<IMainProjectApiService, MainApiProjectService>();
             services.AddScoped<IMainPermissionApiService, MainApiPermissionService>();
             services.AddScoped<IBlobStorage, AzureBlobService>();
             services.AddScoped<IMainCommPkgApiService, MainApiCommPkgService>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -1,5 +1,4 @@
-﻿using Equinor.ProCoSys.PcsBus;
-using Equinor.ProCoSys.PcsBus.Receiver;
+﻿using Equinor.ProCoSys.PcsBus.Receiver;
 using Equinor.ProCoSys.PcsBus.Receiver.Interfaces;
 using Equinor.ProCoSys.IPO.BlobStorage;
 using Equinor.ProCoSys.IPO.Command;
@@ -18,6 +17,7 @@ using Equinor.ProCoSys.IPO.ForeignApi.LibraryApi;
 using Equinor.ProCoSys.IPO.ForeignApi.LibraryApi.FunctionalRole;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Permission;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
@@ -103,8 +103,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IBlobStorage, AzureBlobService>();
             services.AddScoped<ICommPkgApiService, MainApiCommPkgService>();
             services.AddScoped<IMcPkgApiService, MainApiMcPkgService>();
-            services.AddScoped<IFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
+            services.AddScoped<ForeignApi.LibraryApi.FunctionalRole.IFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
             services.AddScoped<IPersonApiService, MainApiPersonService>();
+            services.AddScoped<ForeignApi.MainApi.FunctionalRole.IFunctionalRoleApiService, MainApiFunctionalRoleService>();
 
             services.AddScoped<IInvitationValidator, InvitationValidator>();
             services.AddScoped<IRowVersionValidator, RowVersionValidator>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -104,7 +104,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IMainCommPkgApiService, MainApiCommPkgService>();
             services.AddScoped<IMainMcPkgApiService, MainApiMcPkgService>();
             services.AddScoped<ILibraryFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
-            services.AddScoped<IPersonApiService, MainApiPersonService>();
+            services.AddScoped<IMainPersonApiService, MainApiPersonService>();
             services.AddScoped<IMainFunctionalRoleApiService, MainApiFunctionalRoleService>();
 
             services.AddScoped<IInvitationValidator, InvitationValidator>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/DiModules/ApplicationModule.cs
@@ -102,7 +102,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.DIModules
             services.AddScoped<IPermissionApiService, MainApiPermissionService>();
             services.AddScoped<IBlobStorage, AzureBlobService>();
             services.AddScoped<IMainCommPkgApiService, MainApiCommPkgService>();
-            services.AddScoped<IMcPkgApiService, MainApiMcPkgService>();
+            services.AddScoped<IMainMcPkgApiService, MainApiMcPkgService>();
             services.AddScoped<ILibraryFunctionalRoleApiService, LibraryApiFunctionalRoleService>();
             services.AddScoped<IPersonApiService, MainApiPersonService>();
             services.AddScoped<IMainFunctionalRoleApiService, MainApiFunctionalRoleService>();

--- a/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
         private readonly IUnitOfWork _unitOfWork;
         private readonly ITelemetryClient _telemetryClient;
         private readonly IReadOnlyContext _context;
-        private readonly IMcPkgApiService _mcPkgApiService;
+        private readonly IMainMcPkgApiService _mcPkgApiService;
         private readonly IApplicationAuthenticator _authenticator;
         private readonly IBearerTokenSetter _bearerTokenSetter;
         private const string IpoBusReceiverTelemetryEvent = "IPO Bus Receiver";
@@ -37,7 +37,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
             IUnitOfWork unitOfWork,
             ITelemetryClient telemetryClient,
             IReadOnlyContext context,
-            IMcPkgApiService mcPkgApiService,
+            IMainMcPkgApiService mcPkgApiService,
             IApplicationAuthenticator authenticator,
             IBearerTokenSetter bearerTokenSetter)
         {

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
@@ -9,7 +9,6 @@ using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.IPO.ForeignApi;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,7 +25,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
         private Mock<IUnitOfWork> _unitOfWorkMock;
         private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
-        private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
 
         private AcceptPunchOutCommand _command;
         private AcceptPunchOutCommandHandler _dut;
@@ -158,8 +156,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
             _personRepositoryMock
                 .Setup(x => x.GetByOidAsync(It.IsAny<Guid>()))
                 .Returns(Task.FromResult(currentPerson));
-
-            _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
 
             _invitation.CompleteIpo(
                 participant1,

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
@@ -23,7 +23,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
 
         private AcceptPunchOutCommand _command;
@@ -100,7 +100,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
                 UserName = "ON"
             };
 
-            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock = new Mock<IMainPersonApiService>();
             _personApiServiceMock
                 .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
                     _azureOidForCurrentUser.ToString(), _functionalRoleCode))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
@@ -24,7 +24,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
 
         private CompletePunchOutCommand _command;
@@ -104,7 +104,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
                 UserName = "ON"
             };
 
-            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock = new Mock<IMainPersonApiService>();
             _personApiServiceMock
                 .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
                     _azureOidForCurrentUser.ToString(), _functionalRoleCode))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         private Mock<IFusionMeetingClient> _meetingClientMock;
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<ICommPkgApiService> _commPkgApiServiceMock;
+        private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
         private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
         private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
@@ -136,7 +136,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             _unitOfWorkMock.Setup(x => x.BeginTransaction(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(_transactionMock.Object));
 
-            _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
+            _commPkgApiServiceMock = new Mock<IMainCommPkgApiService>();
 
             _mcPkgDetails1 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system};
             _mcPkgDetails2 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system};

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
         private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
-        private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
+        private Mock<IMainMcPkgApiService> _mcPkgApiServiceMock;
         private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<IOptionsMonitor<MeetingOptions>> _meetingOptionsMock;
@@ -142,7 +142,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             _mcPkgDetails2 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system};
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg>{ _mcPkgDetails1, _mcPkgDetails2 };
 
-            _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
+            _mcPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
             _mcPkgApiServiceMock
                 .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, _mcPkgScope))
                 .Returns(Task.FromResult(mcPkgDetails));

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -32,7 +32,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         private Mock<ICommPkgApiService> _commPkgApiServiceMock;
         private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
         private Mock<IPersonApiService> _personApiServiceMock;
-        private Mock<IFunctionalRoleApiService> _functionalRoleApiServiceMock;
+        private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<IOptionsMonitor<MeetingOptions>> _meetingOptionsMock;
         private Mock<IDbContextTransaction> _transactionMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
@@ -172,7 +172,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             };
             IList<ProCoSysFunctionalRole> frDetails = new List<ProCoSysFunctionalRole>{ _functionalRoleDetails };
 
-            _functionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+            _functionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
             _functionalRoleApiServiceMock
                 .Setup(x => x.GetFunctionalRolesByCodeAsync(_plant, new List<string> { _functionalRoleCode }))
                 .Returns(Task.FromResult(frDetails));

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -31,7 +31,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         private Mock<IUnitOfWork> _unitOfWorkMock;
         private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
         private Mock<IMainMcPkgApiService> _mcPkgApiServiceMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<IOptionsMonitor<MeetingOptions>> _meetingOptionsMock;
         private Mock<IDbContextTransaction> _transactionMock;
@@ -155,7 +155,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
                 Email = "ola@test.com"
             };
 
-            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock = new Mock<IMainPersonApiService>();
             _personApiServiceMock
                 .Setup(x => x.GetPersonByOidWithPrivilegesAsync(_plant,
                     _azureOid.ToString(), "IPO", new List<string> { "SIGN" }))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -31,7 +31,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private Mock<IUnitOfWork> _unitOfWorkMock;
         private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
-        private Mock<ICommPkgApiService> _commPkgApiServiceMock;
+        private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
         private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
         private Mock<IOptionsMonitor<MeetingOptions>> _meetingOptionsMock;
         private Mock<IPersonRepository> _personRepositoryMock;
@@ -149,7 +149,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             //mock comm pkg response from main API
             var commPkgDetails = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, CommStatus = "OK", System = _system};
             IList<ProCoSysCommPkg> pcsCommPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails };
-            _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
+            _commPkgApiServiceMock = new Mock<IMainCommPkgApiService>();
             _commPkgApiServiceMock
                 .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, _commPkgScope))
                 .Returns(Task.FromResult(pcsCommPkgDetails));

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
         private Mock<IPersonApiService> _personApiServiceMock;
-        private Mock<IFunctionalRoleApiService> _functionalRoleApiServiceMock;
+        private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<ICommPkgApiService> _commPkgApiServiceMock;
         private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
         private Mock<IOptionsMonitor<MeetingOptions>> _meetingOptionsMock;
@@ -211,7 +211,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             };
             IList<ProCoSysFunctionalRole> pcsFrDetails = new List<ProCoSysFunctionalRole> { frDetails };
             IList<ProCoSysFunctionalRole> newPcsFrDetails = new List<ProCoSysFunctionalRole> { newFrDetails };
-            _functionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+            _functionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
             _functionalRoleApiServiceMock
                 .Setup(x => x.GetFunctionalRolesByCodeAsync(_plant, new List<string> { _functionalRoleCode }))
                 .Returns(Task.FromResult(pcsFrDetails));

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private Mock<IFusionMeetingClient> _meetingClientMock;
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
         private Mock<IMainMcPkgApiService> _mcPkgApiServiceMock;
@@ -180,7 +180,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 Email = "kari@test.com",
                 UserName = "KN"
             };
-            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock = new Mock<IMainPersonApiService>();
             _personApiServiceMock
                 .Setup(x => x.GetPersonByOidWithPrivilegesAsync(_plant,
                     _azureOid.ToString(), "IPO", new List<string> { "SIGN" }))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -32,7 +32,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
-        private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
+        private Mock<IMainMcPkgApiService> _mcPkgApiServiceMock;
         private Mock<IOptionsMonitor<MeetingOptions>> _meetingOptionsMock;
         private Mock<IPersonRepository> _personRepositoryMock;
 
@@ -158,7 +158,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system};
             var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system};
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
-            _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
+            _mcPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
             _mcPkgApiServiceMock
                 .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, _mcPkgScope))
                 .Returns(Task.FromResult(mcPkgDetails));

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandHandlerTests.cs
@@ -21,7 +21,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
 
         private SignPunchOutCommand _command;
@@ -63,7 +63,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
                 UserName = "KN"
             };
 
-            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock = new Mock<IMainPersonApiService>();
             _personApiServiceMock
                 .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
                     _azureOidForCurrentUser.ToString(), _functionalRoleCode))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
-        private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
+        private Mock<IMainMcPkgApiService> _mcPkgApiServiceMock;
 
         private UnCompletePunchOutCommand _command;
         private UnCompletePunchOutCommandHandler _dut;
@@ -117,7 +117,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
                 .Setup(x => x.GetByIdAsync(It.IsAny<int>()))
                 .Returns(Task.FromResult(_invitation));
 
-            _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
+            _mcPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
 
             //command
             _command = new UnCompletePunchOutCommand(

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
         private Mock<IPlantProvider> _plantProviderMock;
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
         private Mock<IPersonRepository> _personRepositoryMock;
 
@@ -82,7 +82,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
                 UserName = "ON"
             };
 
-            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock = new Mock<IMainPersonApiService>();
             _personApiServiceMock
                 .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
                     _azureOidForCurrentUser.ToString(), _functionalRoleCode))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/PersonCommands/CreateSavedFilter/CreateSavedFilterCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/PersonCommands/CreateSavedFilter/CreateSavedFilterCommandHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.PersonCommands.CreateSavedFilter
     {
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
-        private Mock<IProjectApiService> _projectApiServiceMock;
+        private Mock<IMainProjectApiService> _projectApiServiceMock;
         private Person _person;
         private CreateSavedFilterCommand _command;
         private CreateSavedFilterCommandHandler _dut;
@@ -45,7 +45,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.PersonCommands.CreateSavedFilter
                 Description = "Description", Id = 1, IsClosed = false, Name = _projectName
             };
 
-            _projectApiServiceMock = new Mock<IProjectApiService>();
+            _projectApiServiceMock = new Mock<IMainProjectApiService>();
             _projectApiServiceMock
                 .Setup(x => x.TryGetProjectAsync(TestPlant, _projectName))
                 .Returns(Task.FromResult(project));

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetCommPkgsInProject
     [TestClass]
     public class SearchCommPkgsByCommPkgNoQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<ICommPkgApiService> _commPkgApiServiceMock;
+        private Mock<IMainCommPkgApiService> _commPkgApiServiceMock;
         private IList<ProCoSysCommPkg> _mainApiCommPkgs;
         private GetCommPkgsInProjectQuery _query;
 
@@ -28,7 +28,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetCommPkgsInProject
         {
             using (new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
+                _commPkgApiServiceMock = new Mock<IMainCommPkgApiService>();
                 _mainApiCommPkgs = new List<ProCoSysCommPkg>
                 {
                     new ProCoSysCommPkg

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetFunctionalRoles/GetFunctionalRolesForIpoQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetFunctionalRoles/GetFunctionalRolesForIpoQueryHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetFunctionalRoles
     [TestClass]
     public class GetFunctionalRolesForIpoQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IFunctionalRoleApiService> _functionalRoleApiServiceMock;
+        private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private IList<ProCoSysFunctionalRole> _libraryApiFunctionalRoles;
         private GetFunctionalRolesForIpoQuery _query;
 
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetFunctionalRoles
             {
                 person = new ProCoSysPerson() { AzureOid = "123456", FirstName = "F1", LastName = "F2", UserName = "UN1", Email = "E1@email.com" };
 
-                _functionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+                _functionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
                 _libraryApiFunctionalRoles = new List<ProCoSysFunctionalRole>
                 {
                     new ProCoSysFunctionalRole()

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationById/GetInvitationByIdQueryHandlerTests.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
         private int _invitationId;
         
         private Mock<IFusionMeetingClient> _meetingClientMock;
-        private Mock<IFunctionalRoleApiService> _functionalRoleApiServiceMock;
+        private Mock<ILibraryFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private Mock<ILogger<GetInvitationByIdQueryHandler>> _loggerMock;
 
         private string _functionalRoleCode1 = "FrCode1";
@@ -183,7 +183,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationById
                 IList<ProCoSysFunctionalRole> frDetails = new List<ProCoSysFunctionalRole> { functionalRoleDetails };
                 IList<ProCoSysFunctionalRole> frDetails2 = new List<ProCoSysFunctionalRole> { functionalRoleDetails2 };
 
-                _functionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+                _functionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
                 _functionalRoleApiServiceMock
                     .Setup(x => x.GetFunctionalRolesByCodeAsync(_plantProvider.Plant, new List<string> { _functionalRoleCode1 }))
                     .Returns(Task.FromResult(frDetails));

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetMcPkgsUnderCommPkgInProject/GetMcPkgsByCommPkgNoInProjectQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetMcPkgsUnderCommPkgInProject/GetMcPkgsByCommPkgNoInProjectQueryHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetMcPkgsUnderCommPkgInProject
     [TestClass]
     public class GetMcPkgsByCommPkgNoInProjectQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IMcPkgApiService> _mcPkgApiServiceMock;
+        private Mock<IMainMcPkgApiService> _mcPkgApiServiceMock;
         private IList<ProCoSysMcPkg> _mainApiMcPkgs;
         private GetMcPkgsUnderCommPkgInProjectQuery _query;
 
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetMcPkgsUnderCommPkgInProject
         {
             using (new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
+                _mcPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
                 _mainApiMcPkgs = new List<ProCoSysMcPkg>
                 {
                     new ProCoSysMcPkg

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetOutstandingIpos/GetOutstandingIposQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetOutstandingIpos/GetOutstandingIposQueryHandlerTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.IPO.Infrastructure;
+using Equinor.ProCoSys.IPO.Query.GetOutstandingIpos;
+using Equinor.ProCoSys.IPO.Query.GetOutstandingIPOs;
+using Equinor.ProCoSys.IPO.Test.Common;
+using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using ServiceResult;
+using IFunctionalRoleApiService = Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole.IFunctionalRoleApiService;
+
+namespace Equinor.ProCoSys.IPO.Query.Tests.GetOutstandingIpos
+{
+    [TestClass]
+    public class GetOutstandingIposQueryHandlerTests : ReadOnlyTestsBase
+    {
+        private Mock<IFunctionalRoleApiService> _functionalRoleApiServiceMock;
+        private GetOutstandingIposQuery _query;
+        private Person _person;
+
+        private Invitation _invitationWithPersonParticipant;
+        private Invitation _invitationWithFunctionalRoleParticipant;
+        private string _functionalRoleCode = "FR1";
+
+        protected override void SetupNewDatabase(DbContextOptions<IPOContext> dbContextOptions)
+        {
+            _query = new GetOutstandingIposQuery(ProjectName);
+
+            _person = new Person(_currentUserOid, "test@email.com", "FirstName", "LastName", "UserName");
+            using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                
+                IList<string> pcsFunctionalRoleCodes = new List<string> { _functionalRoleCode };
+
+                _functionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+                _functionalRoleApiServiceMock
+                    .Setup(x => x.GetFunctionalRoleCodesByPersonOidAsync(TestPlant, _currentUserOid.ToString()))
+                    .Returns(Task.FromResult(pcsFunctionalRoleCodes));
+
+                _invitationWithPersonParticipant = new Invitation(
+                    TestPlant,
+                    "TestProject",
+                    "TestInvitation1",
+                    "TestDescription1",
+                    DisciplineType.DP,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
+
+                _invitationWithFunctionalRoleParticipant = new Invitation(
+                    TestPlant,
+                    "TestProject",
+                    "TestInvitation2",
+                    "TestDescription2",
+                    DisciplineType.DP,
+                    new DateTime(),
+                    new DateTime(),
+                    null);
+
+                var FunctionalRoleParticipant = new Participant(
+                    TestPlant,
+                    Organization.Contractor,
+                    IpoParticipantType.FunctionalRole,
+                    _functionalRoleCode,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    1);
+                FunctionalRoleParticipant.SetProtectedIdForTesting(1);
+
+                var PersonParticipant = new Participant(
+                    TestPlant,
+                    Organization.Contractor,
+                    IpoParticipantType.Person,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    _currentUserOid,
+                    0);
+                PersonParticipant.SetProtectedIdForTesting(2);
+
+                _invitationWithPersonParticipant.AddParticipant(PersonParticipant);
+                _invitationWithFunctionalRoleParticipant.AddParticipant(FunctionalRoleParticipant);
+
+                _invitationWithPersonParticipant.CompleteIpo(
+                    PersonParticipant,
+                    PersonParticipant.RowVersion.ConvertToString(),
+                    _person,
+                    new DateTime());
+
+                _invitationWithFunctionalRoleParticipant.CompleteIpo(
+                    FunctionalRoleParticipant,
+                    FunctionalRoleParticipant.RowVersion.ConvertToString(),
+                    _person,
+                    new DateTime());
+
+                context.Invitations.Add(_invitationWithPersonParticipant);
+                context.Invitations.Add(_invitationWithFunctionalRoleParticipant);
+                context.SaveChangesAsync().Wait();
+            }
+        }
+
+        [TestMethod]
+        public async Task Handle_ShouldReturnOkResult()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetOutstandingIposQueryHandler(context, _currentUserProvider, _functionalRoleApiServiceMock.Object, _plantProvider);
+                var result = await dut.Handle(_query, default);
+
+                Assert.AreEqual(ResultType.Ok, result.ResultType);
+            }
+        }
+
+        [TestMethod]
+        public async Task Handle_ShouldReturnCorrectItems()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetOutstandingIposQueryHandler(context, _currentUserProvider, _functionalRoleApiServiceMock.Object, _plantProvider);
+                var result = await dut.Handle(_query, default);
+
+                Assert.AreEqual(2, result.Data.Items.Count());
+                var outstandingInvitationWithPersonParticipant = result.Data.Items.ElementAt(0);
+                Assert.AreEqual(_invitationWithPersonParticipant.Id, outstandingInvitationWithPersonParticipant.InvitationId);
+                Assert.AreEqual(_invitationWithPersonParticipant.Description, outstandingInvitationWithPersonParticipant.Description);
+                var outstandingInvitationWithFunctionalRoleParticipant = result.Data.Items.ElementAt(1);
+                Assert.AreEqual(_invitationWithFunctionalRoleParticipant.Id, outstandingInvitationWithFunctionalRoleParticipant.InvitationId);
+                Assert.AreEqual(_invitationWithFunctionalRoleParticipant.Description, outstandingInvitationWithFunctionalRoleParticipant.Description);
+            }
+        }
+
+        [TestMethod]
+        public async Task Handle_ShouldReturnCorrectItems_WhenUserIsNotInAnyFunctionalRoles()
+        {
+            using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetOutstandingIposQueryHandler(context, _currentUserProvider, _functionalRoleApiServiceMock.Object, _plantProvider);
+                IList<string> EmptyListOfFunctionalRoleCodes = new List<string>();
+                _functionalRoleApiServiceMock
+                    .Setup(x => x.GetFunctionalRoleCodesByPersonOidAsync(TestPlant, _currentUserOid.ToString()))
+                    .Returns(Task.FromResult(EmptyListOfFunctionalRoleCodes));
+
+                var result = await dut.Handle(_query, default);
+
+                Assert.AreEqual(1, result.Data.Items.Count());
+                var outstandingInvitation = result.Data.Items.First();
+                Assert.AreEqual(_invitationWithPersonParticipant.Id, outstandingInvitation.InvitationId);
+                Assert.AreEqual(_invitationWithPersonParticipant.Description, outstandingInvitation.Description);
+            }
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetOutstandingIpos/GetOutstandingIposQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetOutstandingIpos/GetOutstandingIposQueryHandlerTests.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole;
 using Equinor.ProCoSys.IPO.Infrastructure;
 using Equinor.ProCoSys.IPO.Query.GetOutstandingIpos;
 using Equinor.ProCoSys.IPO.Query.GetOutstandingIPOs;
@@ -15,14 +15,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using ServiceResult;
-using IFunctionalRoleApiService = Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole.IFunctionalRoleApiService;
 
 namespace Equinor.ProCoSys.IPO.Query.Tests.GetOutstandingIpos
 {
     [TestClass]
     public class GetOutstandingIposQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IFunctionalRoleApiService> _functionalRoleApiServiceMock;
+        private Mock<IMainFunctionalRoleApiService> _functionalRoleApiServiceMock;
         private GetOutstandingIposQuery _query;
         private Person _person;
 
@@ -40,7 +39,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetOutstandingIpos
                 
                 IList<string> pcsFunctionalRoleCodes = new List<string> { _functionalRoleCode };
 
-                _functionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+                _functionalRoleApiServiceMock = new Mock<IMainFunctionalRoleApiService>();
                 _functionalRoleApiServiceMock
                     .Setup(x => x.GetFunctionalRoleCodesByPersonOidAsync(TestPlant, _currentUserOid.ToString()))
                     .Returns(Task.FromResult(pcsFunctionalRoleCodes));

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetOutstandingIpos/GetOutstandingIposQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetOutstandingIpos/GetOutstandingIposQueryTests.cs
@@ -1,0 +1,19 @@
+﻿using Equinor.ProCoSys.IPO.Query.GetOutstandingIpos;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.IPO.Query.Tests.GetOutstandingIpos
+{
+    [TestClass]
+    public class GetOutstandingIposQueryTests
+    {
+        [TestMethod]
+        public void Constructor_ShouldSetProperties()
+        {
+            // Act 
+            var dut = new GetOutstandingIposQuery("ProjectName");
+
+            // Assert
+            Assert.AreEqual("ProjectName", dut.ProjectName);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersons/GetPersonsQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersons/GetPersonsQueryHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersons
     [TestClass]
     public class GetPersonsQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private IList<ProCoSysPerson> _mainApiPersons;
         private GetPersonsQuery _query;
 
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersons
         {
             using (new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _personApiServiceMock = new Mock<IPersonApiService>();
+                _personApiServiceMock = new Mock<IMainPersonApiService>();
                 _mainApiPersons = new List<ProCoSysPerson>
                 {
                     new ProCoSysPerson

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersonsWithPrivileges/GetPersonsWithPrivilegesQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersonsWithPrivileges/GetPersonsWithPrivilegesQueryHandlerTests.cs
@@ -17,7 +17,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersonsWithPrivileges
     [TestClass]
     public class GetPersonsWithPrivilegesQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<IMainPersonApiService> _personApiServiceMock;
         private IList<ProCoSysPerson> _mainApiContractorPersons;
         private IList<ProCoSysPerson> _mainApiConstructionPersons;
         private GetPersonsWithPrivilegesQuery _query;
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersonsWithPrivileges
         {
             using (new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _personApiServiceMock = new Mock<IPersonApiService>();
+                _personApiServiceMock = new Mock<IMainPersonApiService>();
                 _mainApiContractorPersons = new List<ProCoSysPerson>
                 {
                     new ProCoSysPerson
@@ -59,7 +59,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersonsWithPrivileges
                     }
                 };
 
-                _personApiServiceMock = new Mock<IPersonApiService>();
+                _personApiServiceMock = new Mock<IMainPersonApiService>();
                 _mainApiConstructionPersons = new List<ProCoSysPerson>
                 {
                     new ProCoSysPerson

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetProjectsInPlant/GetProjectsInPlantQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetProjectsInPlant/GetProjectsInPlantQueryHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetProjectsInPlant
     [TestClass]
     public class GetProjectsInPlantQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IProjectApiService> _projectApiServiceMock;
+        private Mock<IMainProjectApiService> _projectApiServiceMock;
         private IList<ProCoSysProject> _mainApiProjects;
         private GetProjectsInPlantQuery _query;
 
@@ -23,7 +23,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetProjectsInPlant
         {
             using (new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _projectApiServiceMock = new Mock<IProjectApiService>();
+                _projectApiServiceMock = new Mock<IMainProjectApiService>();
                 _mainApiProjects = new List<ProCoSysProject>
                 {
                     new ProCoSysProject

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
@@ -147,5 +147,32 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 "AAAAAAAAABA=",
                 HttpStatusCode.Forbidden);
         #endregion
+
+        #region GetOutstandingIpos
+        [TestMethod]
+        public async Task GetOutstandingIpos_AsAnonymous_ShouldReturnUnauthorized()
+            => await PersonsControllerTestsHelper.GetOutstandingIposAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                null,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetOutstandingIpos_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.GetOutstandingIposAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetOutstandingIpos_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await PersonsControllerTestsHelper.GetOutstandingIposAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithAccess,
+                null,
+                HttpStatusCode.Forbidden);
+        #endregion
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsBase.cs
@@ -1,11 +1,37 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.ForeignApi;
+using Equinor.ProCoSys.IPO.ForeignApi.LibraryApi.FunctionalRole;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Project;
+using Fusion.Integration.Meeting;
+using Fusion.Integration.Meeting.Http.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 {
     public class PersonsControllerTestsBase : TestBase
     {
+        private const string AzureOid = "47ff6258-0906-4849-add8-aada76ee0b0d";
+        private const string FunctionalRoleCode = "FRC";
+        protected const string InvitationLocation = "InvitationLocation";
+        private readonly IList<string> _functionalRoleCodes = new List<string> { FunctionalRoleCode };
+        private IList<ProCoSysFunctionalRole> _pcsFunctionalRoles;
+        private List<ProCoSysPerson> _personsInFunctionalRole;
+
+        protected DateTime _invitationStartTime = new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc);
+        protected DateTime _invitationEndTime = new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc);
+
+        protected List<ParticipantsForCommand> _participants;
+        protected List<string> _mcPkgScope;
+        private ProCoSysMcPkg _mcPkgDetails;
+
+        protected TestProfile _sigurdSigner;
+
         [TestInitialize]
         public void TestInitialize()
         {
@@ -14,12 +40,150 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 Description = "description", Id = 1, IsClosed = false, Name = TestFactory.ProjectWithAccess
             };
 
+            _sigurdSigner = TestFactory.Instance.GetTestUserForUserType(UserType.Signer).Profile;
+            var viewer = TestFactory.Instance.GetTestUserForUserType(UserType.Viewer).Profile;
+
+            _participants = new List<ParticipantsForCommand>
+            {
+                new ParticipantsForCommand(
+                    Organization.Contractor,
+                    null,
+                    _sigurdSigner.AsPersonForCommand(true),
+                    null,
+                    0),
+                new ParticipantsForCommand(
+                    Organization.ConstructionCompany,
+                    null,
+                    _sigurdSigner.AsPersonForCommand(true),
+                    null,
+                    1),
+                new ParticipantsForCommand(
+                    Organization.TechnicalIntegrity,
+                    null,
+                    _sigurdSigner.AsPersonForCommand(false),
+                    null,
+                    2)
+            };
+
+            const string McPkgNo = "MC1";
+            _mcPkgScope = new List<string> { McPkgNo };
+
+            _mcPkgDetails = new ProCoSysMcPkg
+            {
+                CommPkgNo = KnownTestData.CommPkgNo,
+                Description = "D1",
+                Id = 1,
+                McPkgNo = McPkgNo,
+                System = KnownTestData.System
+            };
+
+            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { _mcPkgDetails };
+
+            _personsInFunctionalRole = new List<ProCoSysPerson>
+            {
+                new ProCoSysPerson
+                {
+                    AzureOid = AzureOid,
+                    FirstName = "FirstName",
+                    LastName = "LastName",
+                    Email = "Test@email.com",
+                    UserName = "UserName"
+                }
+            };
+
+            _pcsFunctionalRoles = new List<ProCoSysFunctionalRole>
+            {
+                new ProCoSysFunctionalRole
+                {
+                    Code = FunctionalRoleCode,
+                    Description = "Description",
+                    Email = "frEmail@test.com",
+                    InformationEmail = null,
+                    Persons = _personsInFunctionalRole,
+                    UsePersonalEmail = true
+                }
+            };
+
+            var knownGeneralMeeting = new ApiGeneralMeeting
+            {
+                Classification = string.Empty,
+                Contract = null,
+                Convention = string.Empty,
+                DateCreatedUtc = DateTime.MinValue,
+                DateEnd = new ApiDateTimeTimeZoneModel
+                    { DateTimeUtc = _invitationEndTime },
+                DateStart = new ApiDateTimeTimeZoneModel
+                    { DateTimeUtc = _invitationStartTime },
+                ExternalId = null,
+                Id = KnownTestData.MeetingId,
+                InviteBodyHtml = string.Empty,
+                IsDisabled = false,
+                IsOnlineMeeting = false,
+                Location = InvitationLocation,
+                Organizer = new ApiPersonDetailsV1(),
+                OutlookMode = string.Empty,
+                Participants = new List<ApiMeetingParticipant>
+                {
+                    new ApiMeetingParticipant
+                    {
+                        Id = Guid.NewGuid(),
+                        Person = new ApiPersonDetailsV1 {Id = Guid.NewGuid(), Mail = "P1@email.com"},
+                        OutlookResponse = "Required"
+                    },
+                    new ApiMeetingParticipant
+                    {
+                        Id = Guid.NewGuid(),
+                        Person = new ApiPersonDetailsV1 {Id = Guid.NewGuid(), Mail = "FR1@email.com"},
+                        OutlookResponse = "Accepted"
+                    }
+                },
+                Project = null,
+                ResponsiblePersons = new List<ApiPersonDetailsV1>(),
+                Series = null,
+                Title = string.Empty
+            };
+
             TestFactory.Instance
                 .ProjectApiServiceMock
                 .Setup(x => x.TryGetProjectAsync(
                     TestFactory.PlantWithAccess,
                     TestFactory.ProjectWithAccess))
                 .Returns(Task.FromResult(project));
+
+            TestFactory.Instance
+                .MainFunctionalRoleApiServiceMock
+                .Setup(x => x.GetFunctionalRoleCodesByPersonOidAsync(
+                    TestFactory.PlantWithAccess,
+                    viewer.Oid))
+                .Returns(Task.FromResult(_functionalRoleCodes));
+
+            TestFactory.Instance
+                .McPkgApiServiceMock
+                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(
+                    TestFactory.PlantWithAccess,
+                    TestFactory.ProjectWithAccess,
+                    _mcPkgScope))
+                .Returns(Task.FromResult(mcPkgDetails));
+
+            TestFactory.Instance
+                .FunctionalRoleApiServiceMock
+                .Setup(x => x.GetFunctionalRolesByCodeAsync(TestFactory.PlantWithAccess,
+                    new List<string> { FunctionalRoleCode }))
+                .Returns(Task.FromResult(_pcsFunctionalRoles));
+
+            TestFactory.Instance
+                .PersonApiServiceMock
+                .Setup(x => x.GetPersonByOidWithPrivilegesAsync(
+                    TestFactory.PlantWithAccess,
+                    _sigurdSigner.Oid,
+                    "IPO",
+                    It.IsAny<List<string>>()))
+                .Returns(Task.FromResult(_sigurdSigner.AsProCoSysPerson()));
+
+            TestFactory.Instance
+                .FusionMeetingClientMock
+                .Setup(x => x.CreateMeetingAsync(It.IsAny<Action<GeneralMeetingBuilder>>()))
+                .Returns(Task.FromResult(new GeneralMeeting(knownGeneralMeeting)));
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Query.GetOutstandingIpos;
 using Equinor.ProCoSys.IPO.Query.GetSavedFiltersInProject;
 using Equinor.ProCoSys.IPO.WebApi.Controllers.Persons;
 using Newtonsoft.Json;
@@ -121,6 +122,27 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
             var response = await TestFactory.Instance.GetHttpClient(userType, plant).SendAsync(request);
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        public static async Task<OutstandingIposResultDto> GetOutstandingIposAsync(
+            UserType userType,
+            string plant,
+            string projectName,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var project = projectName ?? KnownTestData.ProjectName;
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync($"{Route}/OutstandingIpos?projectName={project}");
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<OutstandingIposResultDto>(jsonString);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -56,7 +56,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public readonly Mock<IMainMcPkgApiService> McPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
         public readonly Mock<IMainPersonApiService> PersonApiServiceMock = new Mock<IMainPersonApiService>();
         public readonly Mock<ILibraryFunctionalRoleApiService> FunctionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
-        public readonly Mock<IProjectApiService> ProjectApiServiceMock = new Mock<IProjectApiService>();
+        public readonly Mock<IMainProjectApiService> ProjectApiServiceMock = new Mock<IMainProjectApiService>();
         public readonly Mock<IBlobStorage> BlobStorageMock = new Mock<IBlobStorage>();
         public readonly Mock<IPcsBusSender> PcsBusSenderMock = new Mock<IPcsBusSender>();
         public readonly Mock<IMainFunctionalRoleApiService> MainFunctionalRoleApiServiceMock = new Mock<IMainFunctionalRoleApiService>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.BlobStorage;
 using Equinor.ProCoSys.IPO.Command;
@@ -55,7 +54,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public readonly Mock<IOptionsMonitor<MeetingOptions>> MeetingOptionsMock = new Mock<IOptionsMonitor<MeetingOptions>>();
         public readonly Mock<IMainCommPkgApiService> CommPkgApiServiceMock = new Mock<IMainCommPkgApiService>();
         public readonly Mock<IMainMcPkgApiService> McPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
-        public readonly Mock<IPersonApiService> PersonApiServiceMock = new Mock<IPersonApiService>();
+        public readonly Mock<IMainPersonApiService> PersonApiServiceMock = new Mock<IMainPersonApiService>();
         public readonly Mock<ILibraryFunctionalRoleApiService> FunctionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
         public readonly Mock<IProjectApiService> ProjectApiServiceMock = new Mock<IProjectApiService>();
         public readonly Mock<IBlobStorage> BlobStorageMock = new Mock<IBlobStorage>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -49,7 +49,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
 
         private readonly Mock<IPlantApiService> _plantApiServiceMock = new Mock<IPlantApiService>();
-        private readonly Mock<IPermissionApiService> _permissionApiServiceMock = new Mock<IPermissionApiService>();
+        private readonly Mock<IMainPermissionApiService> _permissionApiServiceMock = new Mock<IMainPermissionApiService>();
         public readonly Mock<ICurrentUserProvider> CurrentUserProviderMock = new Mock<ICurrentUserProvider>();
         public readonly Mock<IFusionMeetingClient> FusionMeetingClientMock = new Mock<IFusionMeetingClient>();
         public readonly Mock<IOptionsMonitor<MeetingOptions>> MeetingOptionsMock = new Mock<IOptionsMonitor<MeetingOptions>>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -52,7 +52,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public readonly Mock<ICurrentUserProvider> CurrentUserProviderMock = new Mock<ICurrentUserProvider>();
         public readonly Mock<IFusionMeetingClient> FusionMeetingClientMock = new Mock<IFusionMeetingClient>();
         public readonly Mock<IOptionsMonitor<MeetingOptions>> MeetingOptionsMock = new Mock<IOptionsMonitor<MeetingOptions>>();
-        public readonly Mock<ICommPkgApiService> CommPkgApiServiceMock = new Mock<ICommPkgApiService>();
+        public readonly Mock<IMainCommPkgApiService> CommPkgApiServiceMock = new Mock<IMainCommPkgApiService>();
         public readonly Mock<IMcPkgApiService> McPkgApiServiceMock = new Mock<IMcPkgApiService>();
         public readonly Mock<IPersonApiService> PersonApiServiceMock = new Mock<IPersonApiService>();
         public readonly Mock<ILibraryFunctionalRoleApiService> FunctionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -10,6 +10,7 @@ using Equinor.ProCoSys.IPO.Command;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.ForeignApi.LibraryApi.FunctionalRole;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.FunctionalRole;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg;
 using Equinor.ProCoSys.IPO.Infrastructure;
 using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Permission;
@@ -59,6 +60,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public readonly Mock<IProjectApiService> ProjectApiServiceMock = new Mock<IProjectApiService>();
         public readonly Mock<IBlobStorage> BlobStorageMock = new Mock<IBlobStorage>();
         public readonly Mock<IPcsBusSender> PcsBusSenderMock = new Mock<IPcsBusSender>();
+        public readonly Mock<IMainFunctionalRoleApiService> MainFunctionalRoleApiServiceMock = new Mock<IMainFunctionalRoleApiService>();
 
         public static string PlantWithAccess => KnownTestData.Plant;
         public static string PlantWithoutAccess => "PCS$PLANT999";

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -47,7 +47,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         private readonly List<Action> _teardownList = new List<Action>();
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
 
-        private readonly Mock<IPlantApiService> _plantApiServiceMock = new Mock<IPlantApiService>();
+        private readonly Mock<IMainPlantApiService> _plantApiServiceMock = new Mock<IMainPlantApiService>();
         private readonly Mock<IMainPermissionApiService> _permissionApiServiceMock = new Mock<IMainPermissionApiService>();
         public readonly Mock<ICurrentUserProvider> CurrentUserProviderMock = new Mock<ICurrentUserProvider>();
         public readonly Mock<IFusionMeetingClient> FusionMeetingClientMock = new Mock<IFusionMeetingClient>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public readonly Mock<ICommPkgApiService> CommPkgApiServiceMock = new Mock<ICommPkgApiService>();
         public readonly Mock<IMcPkgApiService> McPkgApiServiceMock = new Mock<IMcPkgApiService>();
         public readonly Mock<IPersonApiService> PersonApiServiceMock = new Mock<IPersonApiService>();
-        public readonly Mock<IFunctionalRoleApiService> FunctionalRoleApiServiceMock = new Mock<IFunctionalRoleApiService>();
+        public readonly Mock<ILibraryFunctionalRoleApiService> FunctionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
         public readonly Mock<IProjectApiService> ProjectApiServiceMock = new Mock<IProjectApiService>();
         public readonly Mock<IBlobStorage> BlobStorageMock = new Mock<IBlobStorage>();
         public readonly Mock<IPcsBusSender> PcsBusSenderMock = new Mock<IPcsBusSender>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -54,7 +54,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public readonly Mock<IFusionMeetingClient> FusionMeetingClientMock = new Mock<IFusionMeetingClient>();
         public readonly Mock<IOptionsMonitor<MeetingOptions>> MeetingOptionsMock = new Mock<IOptionsMonitor<MeetingOptions>>();
         public readonly Mock<IMainCommPkgApiService> CommPkgApiServiceMock = new Mock<IMainCommPkgApiService>();
-        public readonly Mock<IMcPkgApiService> McPkgApiServiceMock = new Mock<IMcPkgApiService>();
+        public readonly Mock<IMainMcPkgApiService> McPkgApiServiceMock = new Mock<IMainMcPkgApiService>();
         public readonly Mock<IPersonApiService> PersonApiServiceMock = new Mock<IPersonApiService>();
         public readonly Mock<ILibraryFunctionalRoleApiService> FunctionalRoleApiServiceMock = new Mock<ILibraryFunctionalRoleApiService>();
         public readonly Mock<IProjectApiService> ProjectApiServiceMock = new Mock<IProjectApiService>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -180,6 +180,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                 services.AddScoped(serviceProvider => ProjectApiServiceMock.Object);
                 services.AddScoped(serviceProvider => BlobStorageMock.Object);
                 services.AddScoped(serviceProvider => PcsBusSenderMock.Object);
+                services.AddScoped(serviceProvider => MainFunctionalRoleApiServiceMock.Object);
             });
 
             builder.ConfigureServices(services =>

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Caches/PermissionCacheTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Caches/PermissionCacheTests.cs
@@ -18,7 +18,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Caches
     {
         private PermissionCache _dut;
         private readonly Guid Oid = new Guid("{3BFB54C7-91E2-422E-833F-951AD07FE37F}");
-        private Mock<IPermissionApiService> _permissionApiServiceMock;
+        private Mock<IMainPermissionApiService> _permissionApiServiceMock;
         private readonly string TestPlant = "TestPlant";
         private readonly string Permission1 = "A";
         private readonly string Permission2 = "B";
@@ -31,7 +31,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Caches
         {
             TimeService.SetProvider(new ManualTimeProvider(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
 
-            _permissionApiServiceMock = new Mock<IPermissionApiService>();
+            _permissionApiServiceMock = new Mock<IMainPermissionApiService>();
             _permissionApiServiceMock.Setup(p => p.GetAllOpenProjectsAsync(TestPlant))
                 .Returns(Task.FromResult<IList<ProCoSysProject>>(new List<ProCoSysProject>
             {

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Caches/PlantCacheTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Caches/PlantCacheTests.cs
@@ -18,7 +18,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Caches
     public class PlantCacheTests
     {
         private readonly Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
-        private Mock<IPlantApiService> _plantApiServiceMock;
+        private Mock<IMainPlantApiService> _plantApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
         private readonly string Plant1WithAccess = "P1";
         private readonly string Plant2WithAccess = "P2";
@@ -39,7 +39,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Caches
             _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _currentUserProviderMock.Setup(c => c.GetCurrentUserOid()).Returns(_currentUserOid);
 
-            _plantApiServiceMock = new Mock<IPlantApiService>();
+            _plantApiServiceMock = new Mock<IMainPlantApiService>();
             _plantApiServiceMock.Setup(p => p.GetAllPlantsAsync()).Returns(Task.FromResult(
                 new List<ProCoSysPlant>
                 {

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
         private Mock<IInvitationRepository> _invitationRepository;
         private Mock<IPlantSetter> _plantSetter;
         private Mock<ITelemetryClient> _telemetryClient;
-        private Mock<IMcPkgApiService> _mcPkgApiService;
+        private Mock<IMainMcPkgApiService> _mcPkgApiService;
         private Mock<IReadOnlyContext> _readOnlyContext;
         private Mock<IApplicationAuthenticator> _applicationAuthenticator;
         private Mock<IBearerTokenSetter> _bearerTokenSetter;
@@ -47,7 +47,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Synchronization
             _plantSetter = new Mock<IPlantSetter>();
             _unitOfWork = new Mock<IUnitOfWork>();
             _telemetryClient = new Mock<ITelemetryClient>();
-            _mcPkgApiService = new Mock<IMcPkgApiService>();
+            _mcPkgApiService = new Mock<IMainMcPkgApiService>();
             _readOnlyContext = new Mock<IReadOnlyContext>();
             _applicationAuthenticator = new Mock<IApplicationAuthenticator>();
             _bearerTokenSetter = new Mock<IBearerTokenSetter>();


### PR DESCRIPTION
DevOps#80593 
endpoint to get outstanding invitations for current user
in order to be outstanding an invitation must 
- be ready to be accepted (be completed)
- have current user either as person participant or in functional role as accepter

also a rename with the foreign api service interfaces, since I added a MainApiFunctionalRoleService and there was already a LibraryApiFunctionalRoleService, we would have two interfaces with the same name (FunctionalRoleApiService). to work around this I added the specified api to each service interface name.

