### PR TITLE
Adding an empty swallower (developer mode) for service bus messages

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Startup.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Startup.cs
@@ -9,7 +9,9 @@ using Equinor.ProCoSys.IPO.WebApi.DIModules;
 using Equinor.ProCoSys.IPO.WebApi.Middleware;
 using Equinor.ProCoSys.IPO.WebApi.Misc;
 using Equinor.ProCoSys.IPO.WebApi.Seeding;
+using Equinor.ProCoSys.IPO.WebApi.Synchronization;
 using Equinor.ProCoSys.PcsServiceBus;
+using Equinor.ProCoSys.PcsServiceBus.Sender.Interfaces;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -166,12 +168,15 @@ namespace Equinor.ProCoSys.IPO.WebApi
                     .WithSubscription(PcsTopic.Project, "ipo_project")
                     .WithSubscription(PcsTopic.CommPkg, "ipo_commpkg")
                     .WithSubscription(PcsTopic.McPkg, "ipo_mcpkg"));
-
                 
+                services.AddTopicClients(
+                    Configuration.GetConnectionString("ServiceBus"),
+                    Configuration["ServiceBus:TopicNames"]);
             }
-            services.AddTopicClients(
-                Configuration.GetConnectionString("ServiceBus"),
-                Configuration["ServiceBus:TopicNames"]);
+            else
+            {
+                services.AddSingleton<IPcsBusSender>(new DisabledServiceBusSender());
+            }
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;

--- a/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/DisabledServiceBusSender.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/DisabledServiceBusSender.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Equinor.ProCoSys.PcsServiceBus.Sender.Interfaces;
+
+namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
+{
+    /// Used when service bus is disabled
+    class DisabledServiceBusSender : IPcsBusSender
+    {
+        public Task SendAsync(string topic, string jsonMessage) => Task.CompletedTask;
+
+        public Task CloseAllAsync() => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Adding an empty sender for usage on localhost when all service bus is disabled.

I prefer this over alot of checking inside existing business logic. Open for suggestions.