### PR TITLE
82066 -Filter out accepted invitations

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposForCurrentPersonQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposForCurrentPersonQueryHandler.cs
@@ -43,6 +43,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIpos
             var completedInvitations = await (from i in _context.QuerySet<Invitation>()
                     .Include(ss => ss.Participants)
                                               where i.CompletedAtUtc.HasValue
+                                              where !i.AcceptedAtUtc.HasValue
                                               select i).ToListAsync(cancellationToken);
 
             var currentUsersOutstandingInvitations = new List<Invitation>();


### PR DESCRIPTION
Upon testing the new endpoint I discovered it will still return an invitation as outstanding after it has been accepted. Therefore added a check to filter out accepted IPOs. 