### PR TITLE
81919 - Return commpkg- and mcpkg system in getinvitationbyid

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/CommPkgScopeDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/CommPkgScopeDto.cs
@@ -5,15 +5,18 @@
         public CommPkgScopeDto(
             string commPkgNo,
             string description,
-            string status)
+            string status,
+            string system)
         {
             CommPkgNo = commPkgNo;
             Description = description;
             Status = status;
+            System = system;
         }
 
         public string CommPkgNo { get; }
         public string Description { get; }
         public string Status { get; }
+        public string System { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -194,10 +194,10 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 string.Equals(p.Person.Mail, email, StringComparison.CurrentCultureIgnoreCase))?.Type;
 
         private static IEnumerable<CommPkgScopeDto> ConvertToCommPkgDto(IEnumerable<CommPkg> commPkgs)
-            => commPkgs.Select(commPkg => new CommPkgScopeDto(commPkg.CommPkgNo, commPkg.Description, commPkg.Status));
+            => commPkgs.Select(commPkg => new CommPkgScopeDto(commPkg.CommPkgNo, commPkg.Description, commPkg.Status, commPkg.System));
 
         private static IEnumerable<McPkgScopeDto> ConvertToMcPkgDto(IEnumerable<McPkg> mcPkgs) 
-            => mcPkgs.Select(mcPkg => new McPkgScopeDto(mcPkg.McPkgNo, mcPkg.Description, mcPkg.CommPkgNo));
+            => mcPkgs.Select(mcPkg => new McPkgScopeDto(mcPkg.McPkgNo, mcPkg.Description, mcPkg.CommPkgNo, mcPkg.System));
 
         private IEnumerable<ParticipantDto> ConvertToParticipantDto(IReadOnlyCollection<Participant> participants)
         {

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/McPkgScopeDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/McPkgScopeDto.cs
@@ -5,15 +5,18 @@
         public McPkgScopeDto(
             string mcPkgNo,
             string description,
-            string commPkgNo)
+            string commPkgNo,
+            string system)
         {
             McPkgNo = mcPkgNo;
             Description = description;
             CommPkgNo = commPkgNo;
+            System = system;
         }
 
         public string McPkgNo { get; }
         public string Description { get; }
         public string CommPkgNo { get; }
+        public string System { get; }
     }
 }


### PR DESCRIPTION
Front-end enables/disables the arrows in edit scope based on commpkg- and mcpkg system which has previously never been returned (they have been disabled always until now).

This change does not require changes in any test classes. 