### PR TITLE
82727 missing ipos timeout bug

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/Equinor.ProCoSys.IPO.Command.csproj
+++ b/src/Equinor.ProCoSys.IPO.Command/Equinor.ProCoSys.IPO.Command.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Equinor.ProCoSys.PcsServiceBus" Version="1.5.5" />
     <PackageReference Include="FluentValidation" Version="9.5.3" />
-    <PackageReference Include="Fusion.Integration.Meeting" Version="1.0.0" />
+    <PackageReference Include="Fusion.Integration.Meeting" Version="5.2.1" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.ProCoSys.IPO.Query/Equinor.ProCoSys.IPO.Query.csproj
+++ b/src/Equinor.ProCoSys.IPO.Query/Equinor.ProCoSys.IPO.Query.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fusion.Integration.Meeting" Version="1.0.0" />
+    <PackageReference Include="Fusion.Integration.Meeting" Version="5.2.1" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>

--- a/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.5.3" />
-    <PackageReference Include="Fusion.Integration" Version="3.6.0" />
-    <PackageReference Include="Fusion.Integration.Meeting" Version="1.0.0" />
+    <PackageReference Include="Fusion.Integration" Version="5.3.0" />
+    <PackageReference Include="Fusion.Integration.Meeting" Version="5.2.1" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.2.0" />

--- a/src/Equinor.ProCoSys.IPO.WebApi/Startup.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Startup.cs
@@ -153,7 +153,9 @@ namespace Equinor.ProCoSys.IPO.WebApi
                     opts.ClientId = Configuration["Meetings:ClientId"];                  // Application client ID
                     opts.ClientSecret = Configuration["Meetings:ClientSecret"];          // Application client secret
                 });
-                options.AddMeetings();
+                options.AddMeetings(s => s.SetHttpClientTimeout(
+                    TimeSpan.FromSeconds(Configuration.GetValue<double>("FusionRequestTimeout")),
+                    TimeSpan.FromSeconds(Configuration.GetValue<double>("FusionTotalTimeout"))));
                 options.DisableClaimsTransformation();                                  // Disable this - Fusion adds relevant claims
             });
 

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
@@ -14,6 +14,8 @@
   "UseAzureAppConfiguration": false,
   "EnableServiceBus": false,
   "ServiceBus:TopicNames": "",
+  "FusionRequestTimeout": 110,
+  "FusionTotalTimeout":  100, 
   "Email": {
     "Enabled": false, 
     "From": "",


### PR DESCRIPTION
Bug: User received an error msg when creating an IPO saying he couldn't create the invitation, yet still received the invitation in outlook. Turns out this was because Fusion has a retry policy on their post calls, resulting in them creating the outlook invite even after our requests fail. In our code, when our requests fail, we roll back everything we have created and the invitation is never saved to our db. 

To fix this, Fusion added an upgrade to their nuget package allowing us to manually set the request timeout > total timeout, so that their retry never kicks in. 