### PR TITLE
85857 - utvidelse av export

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExcelQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExcelQueryHandler.cs
@@ -29,11 +29,11 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
 
         public async Task<Result<ExportDto>> Handle(GetInvitationsForExportQuery request, CancellationToken cancellationToken)
         {
-            var invitationsWithIncludes = await GetOrderedInvitationsWithIncludes(request, cancellationToken);
+            var invitationsWithIncludes = await GetOrderedInvitationsWithIncludesAsync(request, cancellationToken);
 
             if (!invitationsWithIncludes.Any())
             {
-                return await CreateSuccessResult(null, request);
+                return await CreateSuccessResultAsync(null, request);
             }
 
             var invitationsToBeExported = await CreateExportInvitationDtosAsync(invitationsWithIncludes);
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
                 await AddHistoryToSingleInvitationInList(invitationsToBeExported, cancellationToken);
             }
 
-            return await CreateSuccessResult(invitationsToBeExported, request);
+            return await CreateSuccessResultAsync(invitationsToBeExported, request);
         }
 
         private async Task AddHistoryToSingleInvitationInList(IEnumerable<ExportInvitationDto> exportInvitationDtos,
@@ -56,7 +56,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
                     cancellationToken));
         }
 
-        private async Task<List<Invitation>> GetOrderedInvitationsWithIncludes(GetInvitationsForExportQuery request,
+        private async Task<List<Invitation>> GetOrderedInvitationsWithIncludesAsync(GetInvitationsForExportQuery request,
             CancellationToken cancellationToken)
         {
             var invitationForQueryDtos = CreateQueryableWithFilter(_context, request.ProjectName, request.Filter, _utcNow);
@@ -68,7 +68,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
             return orderedInvitations.Select(invitation => invitationsWithIncludes.Single(i => i.Id == invitation.Id)).ToList();
         }
 
-        private async Task<SuccessResult<ExportDto>> CreateSuccessResult(List<ExportInvitationDto> exportInvitationDtos, GetInvitationsForExportQuery request)
+        private async Task<SuccessResult<ExportDto>> CreateSuccessResultAsync(List<ExportInvitationDto> exportInvitationDtos, GetInvitationsForExportQuery request)
         {
             var filter = await CreateUsedFilterDtoAsync(request.ProjectName, request.Filter);
 

--- a/src/Equinor.ProCoSys.IPO.WebApi/Excel/ExcelConverter.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Excel/ExcelConverter.cs
@@ -134,36 +134,39 @@ namespace Equinor.ProCoSys.IPO.WebApi.Excel
 
         private void CreateParticipantsSheet(XLWorkbook workbook, IList<ExportInvitationDto> invitations)
         {
-            if (invitations.Count != 1)
-            {
-                return;
-            }
-            var sheet = workbook.Worksheets.Add("Participants");
+            var severalParticipantsSheet = workbook.Worksheets.Add("Participants");
 
-            var rowIdx = 0;
-            var row = sheet.Row(++rowIdx);
-            row.Style.Font.SetBold();
-            row.Style.Font.SetFontSize(12);
-            row.Cell(ParticipantsSheetColumns.IpoNo).Value = "Ipo nr";
-            row.Cell(ParticipantsSheetColumns.Organization).Value = "Organization";
-            row.Cell(ParticipantsSheetColumns.Type).Value = "Type";
-            row.Cell(ParticipantsSheetColumns.Participant).Value = "Participant";
+                var rowIdx = 0;
+                var row = severalParticipantsSheet.Row(++rowIdx);
+                row.Style.Font.SetBold();
+                row.Style.Font.SetFontSize(12);
+                row.Cell(ParticipantsSheetColumns.IpoNo).Value = "Ipo nr";
+                row.Cell(ParticipantsSheetColumns.Organization).Value = "Organization";
+                row.Cell(ParticipantsSheetColumns.Type).Value = "Type";
+                row.Cell(ParticipantsSheetColumns.Participant).Value = "Participant";
 
-            var invitation = invitations.Single();
+                foreach (var invitation in invitations)
+                {
 
-            foreach (var participant in invitation.Participants)
-            {
-                row = sheet.Row(++rowIdx);
+                    foreach (var participant in invitation.Participants)
+                    {
+                        row = severalParticipantsSheet.Row(++rowIdx);
 
-                row.Cell(ParticipantsSheetColumns.IpoNo).SetValue(invitation.Id).SetDataType(XLDataType.Text);
-                row.Cell(ParticipantsSheetColumns.Organization).SetValue(participant.Organization).SetDataType(XLDataType.Text);
-                row.Cell(ParticipantsSheetColumns.Type).SetValue(participant.Type).SetDataType(XLDataType.Text);
-                row.Cell(ParticipantsSheetColumns.Participant).SetValue(participant.Participant).SetDataType(XLDataType.Text);
-            }
+                        row.Cell(ParticipantsSheetColumns.IpoNo).SetValue(invitation.Id).SetDataType(XLDataType.Text);
+                        row.Cell(ParticipantsSheetColumns.Organization).SetValue(participant.Organization)
+                            .SetDataType(XLDataType.Text);
+                        row.Cell(ParticipantsSheetColumns.Type).SetValue(participant.Type).SetDataType(XLDataType.Text);
+                        row.Cell(ParticipantsSheetColumns.Participant).SetValue(participant.Participant)
+                            .SetDataType(XLDataType.Text);
+                    }
 
-            const int minWidth = 10;
-            const int maxWidth = 100;
-            sheet.Columns(1, ParticipantsSheetColumns.Last).AdjustToContents(1, rowIdx, minWidth, maxWidth);
+                    rowIdx++;
+                    row.InsertRowsBelow(1);
+                }
+
+                const int minWidth = 10;
+                const int maxWidth = 100;
+                severalParticipantsSheet.Columns(1, ParticipantsSheetColumns.Last).AdjustToContents(1, rowIdx, minWidth, maxWidth);
         }
 
         private void CreateInvitationSheet(XLWorkbook workbook, IEnumerable<ExportInvitationDto> invitations)


### PR DESCRIPTION
previously upon export of IPOs you could only see participant and history details if there was only **one** IPO in the search result/export. this code includes the participants sheet also if there are several invitations in the export. 
history sheet should still only be included if there is only one IPO. 