### PR TITLE
bug/86260-Rules for Construction Company and Contractor IPO signatures

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
@@ -270,7 +270,9 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
                       p.SortKey > 1 &&
                       (p.Organization == Organization.TechnicalIntegrity ||
                        p.Organization == Organization.Operation ||
-                       p.Organization == Organization.Commissioning)
+                       p.Organization == Organization.Commissioning ||
+                       p.Organization == Organization.Contractor ||
+                       p.Organization == Organization.ConstructionCompany)
                 select p).SingleAsync(cancellationToken);
 
             if (participant.Type == IpoParticipantType.FunctionalRole)


### PR DESCRIPTION
Added Construction companies and Contractors as valid signers as long as they aren't the first ones, as per the new rules.

Completes: AB#86260