### PR TITLE
88613 bugfix handling optimistic concurrency

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
@@ -36,10 +36,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
             RuleForEach(command => command.Participants)
                 .MustAsync((command, participant, _, cancellationToken) => BeAnExistingParticipant(participant.Id, command.InvitationId, cancellationToken))
                 .WithMessage((command, participant) =>
-                    $"Participant with ID does not exist on invitation! Participant={participant}")
+                    $"Participant with ID does not exist on invitation! Participant={participant.Id}")
                 .Must((command, participant) => HaveAValidRowVersion(participant.RowVersion))
                 .WithMessage((command, participant) =>
-                    $"Participant doesn't have valid rowVersion! Participant={participant}");
+                    $"Participant doesn't have valid rowVersion! Participant={participant.Id}");
 
             async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnInvitationInCompletedStage(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is not in completed stage, and thus cannot be accepted!")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AddComment/AddCommentCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AddComment/AddCommentCommandValidator.cs
@@ -20,7 +20,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AddComment
                 //business validators
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeANonCanceledInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is canceled, and thus cannot be commented on!");

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidator.cs
@@ -18,7 +18,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => InvitationIsNotCanceled(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     $"IPO is already canceled! Id={command.InvitationId}")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnInvitationInPlannedStage(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is not in planned stage, and thus cannot be completed!")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
@@ -36,10 +36,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
             RuleForEach(command => command.Participants)
                 .MustAsync((command, participant, _, cancellationToken) => BeAnExistingParticipant(participant.Id, command.InvitationId, cancellationToken))
                 .WithMessage((command, participant) =>
-                    $"Participant with ID does not exist on invitation! Participant={participant}")
+                    $"Participant with ID does not exist on invitation! Participant={participant.Id}")
                 .Must((command, participant) => HaveAValidRowVersion(participant.RowVersion))
                 .WithMessage((command, participant) =>
-                    $"Participant doesn't have valid rowVersion! Participant={participant}");
+                    $"Participant doesn't have valid rowVersion! Participant={participant.Id}");
 
             async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.DeleteAttachment
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitationAsync(command.InvitationId, cancellationToken))
-                    .WithMessage(command => $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    .WithMessage(command => $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnExistingAttachmentAsync(command.InvitationId, command.AttachmentId, cancellationToken))
                     .WithMessage(command => $"Attachment doesn't exist! Attachment={command.AttachmentId}.")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.DeleteAttachment
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitationAsync(command.InvitationId, cancellationToken))
-                    .WithMessage(command => $"Invitation doesn't exist! Invitation={command.InvitationId}.")
+                    .WithMessage(command => $"IPO with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnExistingAttachmentAsync(command.InvitationId, command.AttachmentId, cancellationToken))
                     .WithMessage(command => $"Attachment doesn't exist! Attachment={command.AttachmentId}.")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -250,7 +250,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                             fr.Email,
                             null,
                             participant.SortKey,
-                            participant.FunctionalRole.RowVersion);
+                            participant.RowVersion);
                     }
                     else
                     {
@@ -290,7 +290,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                                     frPerson.Email,
                                     new Guid(frPerson.AzureOid),
                                     participant.SortKey,
-                                    person.RowVersion);
+                                    participant.RowVersion);
                             }
                             else
                             {
@@ -338,7 +338,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                         existingParticipants,
                         participant.Person,
                         participant.SortKey,
-                        participant.Organization);
+                        participant.Organization,
+                        participant.RowVersion);
                     personsAdded.Add(participant);
                 }
             }
@@ -372,7 +373,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                                 person.Email,
                                 new Guid(person.AzureOid),
                                 participant.SortKey,
-                                participant.Person.RowVersion);
+                                participant.RowVersion);
                         }
                         else
                         {
@@ -403,7 +404,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
             IList<Participant> existingParticipants,
             PersonForCommand person,
             int sortKey,
-            Organization organization)
+            Organization organization,
+            string rowVersion)
         {
             var personFromMain = await _personApiService.GetPersonByOidWithPrivilegesAsync(_plantProvider.Plant,
                 person.AzureOid.ToString(), _objectName, _signerPrivileges);
@@ -422,7 +424,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                         personFromMain.Email,
                         new Guid(personFromMain.AzureOid),
                         sortKey,
-                        person.RowVersion);
+                        rowVersion);
                 }
                 else
                 {
@@ -468,7 +470,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                         participant.Person.Email,
                         null,
                         participant.SortKey,
-                        participant.Person.RowVersion);
+                        participant.RowVersion);
                 }
                 else
                 {
@@ -512,7 +514,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                         participant.ExternalEmail.Email,
                         null,
                         participant.SortKey,
-                        participant.ExternalEmail.RowVersion);
+                        participant.RowVersion);
                 }
                 else
                 {

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandValidator.cs
@@ -36,7 +36,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     $"Title must be between {Invitation.TitleMinLength} and {Invitation.TitleMaxLength} characters! Title={command.Title}")
                 //business validators
                 .MustAsync((command, cancellationToken) => BeAnExistingIpo(command.InvitationId, cancellationToken))
-                .WithMessage(command => $"IPO with this ID does not exist! Id={command.InvitationId}")
+                .WithMessage(command => $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnIpoInPlannedStage(command.InvitationId, cancellationToken))
                 .WithMessage(command => $"IPO must be in planned stage to be edited! Id={command.InvitationId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandValidator.cs
@@ -86,28 +86,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                 => rowVersionValidator.IsValid(rowVersion);
 
             bool ParticipantsHaveValidRowVersions(ParticipantsForCommand participant)
-            {
-                if (participant.ExternalEmail?.Id != null)
-                {
-                    return rowVersionValidator.IsValid(participant.ExternalEmail.RowVersion);
-                }
-                if (participant.Person?.Id != null)
-                {
-                    return rowVersionValidator.IsValid(participant.Person.RowVersion);
-                }
-
-                if (participant.FunctionalRole != null)
-                {
-                    if (participant.FunctionalRole.Id != null && !rowVersionValidator.IsValid(participant.FunctionalRole.RowVersion))
-                    {
-                        return false;
-                    }
-
-                    return participant.FunctionalRole.Persons.All(person => person.Id == null || rowVersionValidator.IsValid(person.RowVersion));
-                }
-
-                return true;
-            }
+                => rowVersionValidator.IsValid(participant.RowVersion);
         }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/ExternalEmailForCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/ExternalEmailForCommand.cs
@@ -1,21 +1,15 @@
-﻿using MediatR;
-using ServiceResult;
-
-namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
+﻿namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 {
-    public class ExternalEmailForCommand : IRequest<Result<Unit>>
+    public class ExternalEmailForCommand
     {
         public ExternalEmailForCommand(
             string email,
-            int? id = null,
-            string rowVersion = null)
+            int? id = null)
         {
             Email = email;
             Id = id;
-            RowVersion = rowVersion;
         }
         public string Email { get; }
         public int? Id { get; }
-        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/FunctionalRoleForCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/FunctionalRoleForCommand.cs
@@ -1,25 +1,20 @@
 ﻿using System.Collections.Generic;
-using MediatR;
-using ServiceResult;
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 {
-    public class FunctionalRoleForCommand : IRequest<Result<Unit>>
+    public class FunctionalRoleForCommand
     {
         public FunctionalRoleForCommand(
             string code,
             IList<PersonForCommand> persons,
-            int? id = null,
-            string rowVersion = null)
+            int? id = null)
         {
             Code = code;
             Persons = persons ?? new List<PersonForCommand>();
             Id = id;
-            RowVersion = rowVersion;
         }
         public string Code { get; }
         public IList<PersonForCommand> Persons { get; }
         public int? Id { get; }
-        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/FunctionalRoleForCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/FunctionalRoleForCommandValidator.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 {
+    // todo Dead code. This validator will never be hit. Move to CreateInvitationCommandValidator and EditInvitationCommandValidator
     public class FunctionalRoleForCommandValidator : AbstractValidator<FunctionalRoleForCommand>
     {
         public FunctionalRoleForCommandValidator()

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/ParticipantsForCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/ParticipantsForCommand.cs
@@ -1,28 +1,29 @@
 ﻿using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
-using MediatR;
-using ServiceResult;
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 {
-    public class ParticipantsForCommand : IRequest<Result<Unit>>
+    public class ParticipantsForCommand
     {
         public ParticipantsForCommand(
             Organization organization,
             ExternalEmailForCommand externalEmail,
             PersonForCommand person,
             FunctionalRoleForCommand functionalRole,
-            int sortKey)
+            int sortKey,
+            string rowVersion)
         {
             Organization = organization;
             FunctionalRole = functionalRole;
             Person = person;
             ExternalEmail = externalEmail;
             SortKey = sortKey;
+            RowVersion = rowVersion;
         }
         public Organization Organization { get; }
         public int SortKey { get; }
         public ExternalEmailForCommand ExternalEmail { get; }
         public PersonForCommand Person { get; }
         public FunctionalRoleForCommand FunctionalRole { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/ParticipantsForCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/ParticipantsForCommandValidator.cs
@@ -2,6 +2,7 @@
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 {
+    // todo Dead code. This validator will never be hit. Move to CreateInvitationCommandValidator and EditInvitationCommandValidator
     public class ParticipantsForCommandValidator : AbstractValidator<ParticipantsForCommand>
     {
         public ParticipantsForCommandValidator()

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/PersonForCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/PersonForCommand.cs
@@ -1,28 +1,23 @@
 ﻿using System;
-using MediatR;
-using ServiceResult;
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 {
-    public class PersonForCommand : IRequest<Result<Unit>>
+    public class PersonForCommand
     {
         public PersonForCommand(
             Guid? azureOid,
             string email,
             bool required,
-            int? id = null,
-            string rowVersion = null)
+            int? id = null)
         {
             AzureOid = azureOid;
             Email = email;
             Required = required;
             Id = id;
-            RowVersion = rowVersion;
         }
         public Guid? AzureOid { get; }
         public string Email { get; }
         public bool Required { get; }
         public int? Id { get; }
-        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnExistingParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     $"Participant with ID does not exist on invitation! Id={command.ParticipantId}")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
@@ -19,7 +19,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
                     $"IPO with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnExistingParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"Participant with this ID does not exist! Id={command.ParticipantId}")
+                    $"Participant with ID does not exist on invitation! Id={command.ParticipantId}")
                 .MustAsync((command, cancellationToken) => BeANonCanceledInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is canceled, and thus cannot be signed!")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnInvitationInAcceptedStage(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is not in accepted stage, and thus cannot be unaccepted!")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnInvitationInCompletedStage(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is not in completed stage, and thus cannot be uncompleted!")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusAn
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => BeAnInvitationInCompletedStage(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     "Invitation is not in completed stage, and thus cannot change attended statuses or notes!")

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidator.cs
@@ -34,7 +34,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UploadAttachment
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitationAsync(command.InvitationId, cancellationToken))
-                    .WithMessage(command => $"IPO with this ID does not exist! Id={command.InvitationId}")
+                    .WithMessage(command => $"Invitation with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => NotHaveAttachmentWithFileNameAsync(command.InvitationId, command.FileName, cancellationToken))
                     .WithMessage(command => $"Invitation already has an attachment with filename {command.FileName}! Please rename file or choose to overwrite.")
                     .When(c => !c.OverWriteIfExists, ApplyConditionTo.CurrentValidator);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidator.cs
@@ -34,7 +34,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UploadAttachment
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitationAsync(command.InvitationId, cancellationToken))
-                    .WithMessage(command => $"Invitation doesn't exist! Invitation={command.InvitationId}")
+                    .WithMessage(command => $"IPO with this ID does not exist! Id={command.InvitationId}")
                 .MustAsync((command, cancellationToken) => NotHaveAttachmentWithFileNameAsync(command.InvitationId, command.FileName, cancellationToken))
                     .WithMessage(command => $"Invitation already has an attachment with filename {command.FileName}! Please rename file or choose to overwrite.")
                     .When(c => !c.OverWriteIfExists, ApplyConditionTo.CurrentValidator);

--- a/src/Equinor.ProCoSys.IPO.Command/PersonCommands/DeleteSavedFilter/DeleteSavedFilterCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/PersonCommands/DeleteSavedFilter/DeleteSavedFilterCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.PersonCommands.DeleteSavedFilter
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingSavedFilterAsync(command.SavedFilterId, cancellationToken))
-                .WithMessage(command => $"Saved filter doesn't exist! Saved filter={command.SavedFilterId}")
+                .WithMessage(command => $"Saved filter with this ID does not exist! Id={command.SavedFilterId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 

--- a/src/Equinor.ProCoSys.IPO.Command/PersonCommands/UpdateSavedFilter/UpdateSavedFilterCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/PersonCommands/UpdateSavedFilter/UpdateSavedFilterCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Command.PersonCommands.UpdateSavedFilter
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingSavedFilterAsync(command.SavedFilterId, cancellationToken))
-                .WithMessage(command => $"Saved filter doesn't exist! Saved filter={command.SavedFilterId}")
+                .WithMessage(command => $"Saved filter with this ID does not exist! Id={command.SavedFilterId}")
                 .MustAsync((command, cancellationToken) => HaveAUniqueTitleForPerson(command.Title, command.SavedFilterId, cancellationToken))
                 .WithMessage(command => $"A saved filter with this title already exists! Title={command.Title}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))

--- a/src/Equinor.ProCoSys.IPO.Domain/EntityBase.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/EntityBase.cs
@@ -18,7 +18,6 @@ namespace Equinor.ProCoSys.IPO.Domain
         public virtual int Id { get; protected set; }
 
         public readonly byte[] RowVersion = new byte[8];
-        
 
         public void AddPreSaveDomainEvent(INotification eventItem)
         {
@@ -32,9 +31,13 @@ namespace Equinor.ProCoSys.IPO.Domain
             _postSaveDomainEvents.Add(eventItem);
         }
 
-        public virtual void SetRowVersion(string value)
+        public virtual void SetRowVersion(string rowVersion)
         {
-            var newRowVersion = Convert.FromBase64String(value);
+            if (string.IsNullOrEmpty(rowVersion))
+            {
+                throw new ArgumentNullException(nameof(rowVersion));
+            }
+            var newRowVersion = Convert.FromBase64String(rowVersion);
             for (var index = 0; index < newRowVersion.Length; index++)
             {
                 RowVersion[index] = newRowVersion[index];

--- a/src/Equinor.ProCoSys.IPO.Domain/IPlantProvider.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/IPlantProvider.cs
@@ -3,5 +3,10 @@
     public interface IPlantProvider
     {
         string Plant { get; }
+
+        // HACK To be removed after bugfixed optimistic concurreny
+        // This prop is misplaced here since this interface is alredt injected into IPOContext where needed.
+        // This to not break 100+ constructions of IPOContext in tests
+        bool IsOptimisticConcurrenyEnabled_HACK { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/IPOContext.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/IPOContext.cs
@@ -96,6 +96,10 @@ namespace Equinor.ProCoSys.IPO.Infrastructure
 
         private void UpdateConcurrencyToken()
         {
+            if (!_plantProvider.IsOptimisticConcurrenyEnabled_HACK)
+            {
+                return;
+            }
             var modifiedEntries = ChangeTracker
                 .Entries<EntityBase>()
                 .Where(x => x.State == EntityState.Modified || x.State == EntityState.Deleted);

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/IPOContext.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/IPOContext.cs
@@ -75,6 +75,8 @@ namespace Equinor.ProCoSys.IPO.Infrastructure
         {
             await DispatchPreSaveEventsAsync(cancellationToken);
             await SetAuditDataAsync();
+            UpdateConcurrencyToken();
+            
             try
             {
                 var result = await base.SaveChangesAsync(cancellationToken);
@@ -91,6 +93,23 @@ namespace Equinor.ProCoSys.IPO.Infrastructure
             => await base.Database.BeginTransactionAsync(cancellationToken);
 
         public void Commit() => base.Database.CommitTransaction();
+
+        private void UpdateConcurrencyToken()
+        {
+            var modifiedEntries = ChangeTracker
+                .Entries<EntityBase>()
+                .Where(x => x.State == EntityState.Modified || x.State == EntityState.Deleted);
+
+            foreach (var entry in modifiedEntries)
+            {
+                var currentRowVersion = entry.CurrentValues.GetValue<byte[]>(nameof(EntityBase.RowVersion));
+                var originalRowVersion = entry.OriginalValues.GetValue<byte[]>(nameof(EntityBase.RowVersion));
+                for (var i = 0; i < currentRowVersion.Length; i++)
+                {
+                    originalRowVersion[i] = currentRowVersion[i];
+                }
+            }
+        }
 
         private async Task DispatchPreSaveEventsAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -222,7 +222,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         IsSigningParticipant(participant) && CurrentUserCanSignAsPersonInFunctionalRole(participant).Result,
                         null,
                         null,
-                        ConvertToFunctionalRoleDto(participant, personsInFunctionalRole)));
+                        ConvertToFunctionalRoleDto(participant, personsInFunctionalRole),
+                        participant.RowVersion.ConvertToString()));
                 }
                 else if (ParticipantIsNotInFunctionalRole(participant) && participant.Organization != Organization.External)
                 {
@@ -236,7 +237,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         IsSigningParticipant(participant) && _currentUserProvider.GetCurrentUserOid() == participant.AzureOid,
                         null,
                         ConvertToInvitedPersonDto(participant), 
-                        null));
+                        null,
+                        participant.RowVersion.ConvertToString()));
                 }
                 else if (participant.Organization == Organization.External)
                 {
@@ -251,7 +253,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         new ExternalEmailDto(participant.Id, participant.Email,
                             participant.RowVersion.ConvertToString()),
                         null,
-                        null));
+                        null,
+                        participant.RowVersion.ConvertToString()));
                 }
             }
 

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -15,7 +15,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             bool canSign,
             ExternalEmailDto externalEmail,
             InvitedPersonDto person,
-            FunctionalRoleDto functionalRole)
+            FunctionalRoleDto functionalRole,
+            string rowVersion)
         {
             Organization = organization;
             SortKey = sortKey;
@@ -27,6 +28,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             ExternalEmail = externalEmail;
             Person = person;
             FunctionalRole = functionalRole;
+            RowVersion = rowVersion;
         }
 
         public Organization Organization { get; }
@@ -39,5 +41,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public ExternalEmailDto ExternalEmail { get; }
         public InvitedPersonDto Person { get; }
         public FunctionalRoleDto FunctionalRole { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/ExternalEmailDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/ExternalEmailDto.cs
@@ -3,7 +3,6 @@
     public class ExternalEmailDto
     {
         public int? Id { get; set; }
-        public string RowVersion { get; set; }
         public string Email { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FunctionalRoleDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FunctionalRoleDto.cs
@@ -5,7 +5,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
     public class FunctionalRoleDto
     {
         public int? Id { get; set; }
-        public string RowVersion { get; set; }
         public string Code { get; set; }
         public IEnumerable<PersonDto> Persons { get; set; }
     }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
@@ -425,16 +425,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
                     p.ExternalEmail != null
                         ? new ExternalEmailForCommand(
                             p.ExternalEmail.Email,
-                            p.ExternalEmail.Id,
-                            p.ExternalEmail.RowVersion)
+                            p.ExternalEmail.Id)
                         : null,
                     p.Person != null
                         ? new PersonForCommand(
                             p.Person.AzureOid,
                             p.Person.Email,
                             p.Person.Required,
-                            p.Person.Id,
-                            p.Person.RowVersion)
+                            p.Person.Id)
                         : null,
                     p.FunctionalRole != null
                         ? new FunctionalRoleForCommand(
@@ -444,12 +442,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
                                     person.AzureOid,
                                     person.Email,
                                     person.Required,
-                                    person.Id,
-                                    person.RowVersion)).ToList(),
-                            p.FunctionalRole.Id,
-                            p.FunctionalRole.RowVersion)
+                                    person.Id)).ToList(),
+                            p.FunctionalRole.Id)
                         : null,
-                    p.SortKey)
+                    p.SortKey,
+                    p.RowVersion)
             ).ToList();
 
         private static GetInvitationsQuery CreateGetInvitationsQuery(FilterDto filter, SortingDto sorting, PagingDto paging)

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/ParticipantDto.cs
@@ -9,5 +9,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
         public ExternalEmailDto ExternalEmail { get; set; }
         public PersonDto Person { get; set; }
         public FunctionalRoleDto FunctionalRole { get; set; }
+        public string RowVersion { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/PersonDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/PersonDto.cs
@@ -5,7 +5,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
     public class PersonDto
     {
         public int? Id { get; set; }
-        public string RowVersion { get; set; }
         public Guid? AzureOid { get; set; }
         public string Email { get; set; }
         public bool Required { get; set; }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Misc/PlantProvider.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Misc/PlantProvider.cs
@@ -1,10 +1,18 @@
 ﻿using Equinor.ProCoSys.IPO.Domain;
+using Microsoft.Extensions.Configuration;
 
 namespace Equinor.ProCoSys.IPO.WebApi.Misc
 {
     public class PlantProvider : IPlantProvider, IPlantSetter
     {
+        private readonly IConfiguration _configuration;
+
+        public PlantProvider(IConfiguration configuration) => _configuration = configuration;
+
         public string Plant { get; private set; }
+
+        public bool IsOptimisticConcurrenyEnabled_HACK
+            => _configuration.GetValue("IsOptimisticConcurrenyEnabled", false);
 
         public void SetPlant(string plant) => Plant = plant;
     }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Seeding/SeedingPlantProvider.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Seeding/SeedingPlantProvider.cs
@@ -7,6 +7,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.Seeding
         public SeedingPlantProvider(string plant) => Plant = plant;
 
         public string Plant { get; }
+
+        public bool IsOptimisticConcurrenyEnabled_HACK => throw new System.NotImplementedException();
+
         public void SetTemporaryPlant(string plant) => throw new System.NotImplementedException();
         public void ReleaseTemporaryPlant() => throw new System.NotImplementedException();
     }

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
@@ -35,6 +35,7 @@
     "ServiceBus": "",
     "AppConfig": ""
   },
+  "IsOptimisticConcurrenyEnabled": false,
   "LibraryApi:BaseAddress": "",
   "Logging": {
     "LogLevel": {

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
@@ -67,13 +67,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
                 null,
                 null,
                 new FunctionalRoleForCommand(_functionalRoleCode, null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(_azureOidForCurrentUser, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         [TestInitialize]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidatorTests.cs
@@ -78,7 +78,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AddComment/AddCommentCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AddComment/AddCommentCommandValidatorTests.cs
@@ -46,7 +46,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AddComment
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidatorTests.cs
@@ -49,7 +49,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandHandlerTests.cs
@@ -71,13 +71,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
                 null,
                 null,
                 new FunctionalRoleForCommand(_functionalRoleCode, null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(_azureOid, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         [TestInitialize]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidatorTests.cs
@@ -81,7 +81,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -56,13 +56,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
                 null,
                 null,
                 new FunctionalRoleForCommand(_functionalRoleCode, null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(_azureOid, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         private ProCoSysPerson _personDetails;

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandTests.cs
@@ -18,13 +18,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
                 null, 
                 null, 
                 new FunctionalRoleForCommand("FR1", null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(null, "ola@test.com", true), 
                 null,
-                1)
+                1,
+                null)
         };
 
         private readonly string _projectName = "Project name";

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandValidatorTests.cs
@@ -29,13 +29,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
                 null,
                 null,
                 new FunctionalRoleForCommand("FR1", null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(null, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         [TestInitialize]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidatorTests.cs
@@ -57,7 +57,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.DeleteAttachment
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation doesn't exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/DeleteAttachment/DeleteAttachmentCommandValidatorTests.cs
@@ -57,7 +57,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.DeleteAttachment
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private EditInvitationCommandHandler _dut;
         private const string _plant = "PCS$TEST_PLANT";
         private const string _rowVersion = "AAAAAAAAABA=";
-        private const string _participantRowVersion = "AAAAAAAAABA=";
+        private const string _participantRowVersion = "AAAAAAAAJ00=";
         private const int _participantId = 20;
         private const string _projectName = "Project name";
         private const string _title = "Test title";
@@ -68,21 +68,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private const string _commPkgNo2 = "Comm2";
         private const string _system = "1|2";
         private const string _system2 = "2|2";
-        private readonly List<ParticipantsForCommand> _participants = new List<ParticipantsForCommand>
-        {
-            new ParticipantsForCommand(
-                Organization.Contractor,
-                null,
-                null,
-                new FunctionalRoleForCommand(_functionalRoleCode, null),
-                0),
-            new ParticipantsForCommand(
-                Organization.ConstructionCompany,
-                null,
-                new PersonForCommand(_azureOid, "ola@test.com", true),
-                null,
-                1)
-        };
 
         private readonly List<ParticipantsForCommand> _updatedParticipants = new List<ParticipantsForCommand>
         {
@@ -90,14 +75,16 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 Organization.Contractor,
                 null,
                 null,
-                new FunctionalRoleForCommand(_newFunctionalRoleCode, null, _participantId, _participantRowVersion),
-                0),
+                new FunctionalRoleForCommand(_newFunctionalRoleCode, null, _participantId),
+                0,
+                _participantRowVersion),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(_newAzureOid, "kari@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         private readonly List<string> _mcPkgScope = new List<string>
@@ -265,9 +252,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             var participant = new Participant(
                 _plant,
-                _participants[0].Organization,
+                Organization.Contractor,
                 IpoParticipantType.FunctionalRole,
-                _participants[0].FunctionalRole.Code,
+                _functionalRoleCode,
                 null,
                 null,
                 null,
@@ -278,14 +265,14 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             _dpInvitation.AddParticipant(participant);
             _dpInvitation.AddParticipant(new Participant(
                 _plant,
-                _participants[1].Organization,
+                Organization.ConstructionCompany,
                 IpoParticipantType.Person,
                 null,
                 _firstName,
                 _lastName,
                 null,
-                _participants[1].Person.Email,
-                _participants[1].Person.AzureOid,
+                "ola@test.com",
+                _azureOid,
                 1));
             _dpInvitation.SetProtectedIdForTesting(_dpInvitationId);
 
@@ -681,6 +668,10 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
             Assert.AreEqual(_rowVersion, result.Data);
             Assert.AreEqual(_rowVersion, _dpInvitation.RowVersion.ConvertToString());
+            foreach (var participant in _dpInvitation.Participants)
+            {
+                var r = participant.RowVersion.ConvertToString();
+            }
             Assert.IsTrue(_dpInvitation.Participants.Any(p => p.RowVersion.ConvertToString() == _participantRowVersion));
         }
     }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -668,10 +668,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
             Assert.AreEqual(_rowVersion, result.Data);
             Assert.AreEqual(_rowVersion, _dpInvitation.RowVersion.ConvertToString());
-            foreach (var participant in _dpInvitation.Participants)
-            {
-                var r = participant.RowVersion.ConvertToString();
-            }
             Assert.IsTrue(_dpInvitation.Participants.Any(p => p.RowVersion.ConvertToString() == _participantRowVersion));
         }
     }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandTests.cs
@@ -17,13 +17,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 null,
                 null,
                 new FunctionalRoleForCommand("FR1", null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(null, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         private const string Title = "Test title";

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandValidatorTests.cs
@@ -34,13 +34,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 null,
                 null,
                 new FunctionalRoleForCommand("FR1", null),
-                0),
+                0,
+                _rowVersion),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(null, "ola@test.com", true),
                 null,
-                1)
+                1,
+                _rowVersion)
         };
 
         [TestInitialize]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandValidatorTests.cs
@@ -92,7 +92,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/ParticipantsForCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/ParticipantsForCommandValidatorTests.cs
@@ -21,13 +21,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands
                     null,
                     null,
                     new FunctionalRoleForCommand("FR1", null),
-                    0);
+                    0,
+                    null);
             _invalidCommandNegativeSortKey = new ParticipantsForCommand(
                     Organization.ConstructionCompany,
                     null,
                     new PersonForCommand(null,"ola@test.com", true),
                     null,
-                    -1);
+                    -1,
+                    null);
             _dut = new ParticipantsForCommandValidator();
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
@@ -67,7 +67,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant with ID does not exist on invitation!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandHandlerTests.cs
@@ -46,13 +46,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnAcceptPunchOut
                 null,
                 null,
                 new FunctionalRoleForCommand(_functionalRoleCode, null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(_azureOidForCurrentUser, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         [TestInitialize]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidatorTests.cs
@@ -56,7 +56,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnAcceptPunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
@@ -48,13 +48,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
                 null,
                 null,
                 new FunctionalRoleForCommand(_functionalRoleCode, null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(_azureOidForCurrentUser, "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         [TestInitialize]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidatorTests.cs
@@ -56,7 +56,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidatorTests.cs
@@ -76,7 +76,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidatorTests.cs
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UploadAttachment
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidatorTests.cs
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UploadAttachment
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation doesn't exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("IPO with this ID does not exist"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/PersonCommands/DeleteSavedFilter/DeleteSavedFilterCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/PersonCommands/DeleteSavedFilter/DeleteSavedFilterCommandValidatorTests.cs
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.PersonCommands.DeleteSavedFilter
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Saved filter doesn't exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Saved filter with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/PersonCommands/UpdateSavedFilter/UpdateSavedFilterCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/PersonCommands/UpdateSavedFilter/UpdateSavedFilterCommandValidatorTests.cs
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.PersonCommands.UpdateSavedFilter
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Saved filter doesn't exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Saved filter with this ID does not exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -62,13 +62,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 null,
                 null,
                 new FunctionalRoleForCommand("FR1", null),
-                0),
+                0,
+                null),
             new ParticipantsForCommand(
                 Organization.ConstructionCompany,
                 null,
                 new PersonForCommand(new Guid("11111111-2222-2222-2222-333333333333"), "ola@test.com", true),
                 null,
-                1)
+                1,
+                null)
         };
 
         private readonly List<Attachment> _attachments = new List<Attachment>
@@ -508,13 +510,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         new ExternalEmailForCommand("external@test.com"),
                         null,
                         null,
-                        0),
+                        0,
+                        null),
                     new ParticipantsForCommand(
                         Organization.ConstructionCompany,
                         new ExternalEmailForCommand("external2@test.com"),
                         null,
                         null,
-                        1)
+                        1,
+                        null)
                 });
                 Assert.IsFalse(result);
             }
@@ -543,13 +547,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand("FR1", null),
-                        0),
+                        0,
+                        null),
                     new ParticipantsForCommand(
                         Organization.Operation,
                         null,
                         new PersonForCommand(Guid.Empty, "ola@test.com", true),
                         null,
-                        1)
+                        1,
+                        null)
                 });
                 Assert.IsFalse(result);
             }
@@ -580,7 +586,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         null,
-                        3)
+                        3,
+                    null)
                 });
                 Assert.IsFalse(result);
             }
@@ -600,7 +607,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         new ExternalEmailForCommand("test@email.com"),
                         new PersonForCommand(null, "zoey@test.com", true),
                         null,
-                        3)
+                        3,
+                        null)
                 });
                 Assert.IsFalse(result);
             }
@@ -618,21 +626,24 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand("FR1", null),
-                        2);
+                        2,
+                        null);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
                         null,
                         new PersonForCommand(new Guid("11111111-2222-2222-2222-333333333333"), "zoey@test.com", true),
                         null,
-                        3);
+                        3,
+                        null);
                 var external =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
                         new ExternalEmailForCommand("External@test.com"),
                         null,
                         null,
-                        4);
+                        4,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], fr, person, external });
                 Assert.IsTrue(result);
@@ -651,7 +662,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(new Guid("11111111-2222-2222-2222-333333333333"), null, true),
                         null,
-                        3);
+                        3,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsTrue(result);
@@ -670,7 +682,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(new Guid("11111111-2222-2222-2222-333333333333"), "", true),
                         null,
-                        3);
+                        3,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsTrue(result);
@@ -689,7 +702,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(null, "zoey@test.com", true),
                         null,
-                        3);
+                        3,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsTrue(result);
@@ -709,7 +723,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                     new FunctionalRoleForCommand(
                         "FR",
                         new List<PersonForCommand>{ new PersonForCommand(new Guid("11111111-2222-2222-2222-333333333333"), "", true)}), 
-                    3);
+                    3,
+                    null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], fr });
                 Assert.IsTrue(result);
@@ -729,7 +744,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         new ExternalEmailForCommand("external@test.com"),
                         null,
                         new FunctionalRoleForCommand("FR1", null),
-                        3);
+                        3,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], participantWithFunctionalRoleAndExternalEmail });
                 Assert.IsFalse(result);
@@ -749,7 +765,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand(null, null),
-                        3);
+                        3,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], participantWithFunctionalRoleAndExternalEmail });
                 Assert.IsFalse(result);
@@ -769,7 +786,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand("", null),
-                        3);
+                        3,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], participantWithFunctionalRoleAndExternalEmail });
                 Assert.IsFalse(result);
@@ -789,7 +807,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(null, null, true),
                         null,
-                        4);
+                        4,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsFalse(result);
@@ -809,7 +828,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(Guid.Empty, "test", true),
                         null,
-                        4);
+                        4,
+                        null);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsFalse(result);
@@ -841,7 +861,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(null, "zoey@test.com", true),
                         null,
-                        3);
+                        3,
+                        null);
                 var result = dut.OnlyRequiredParticipantsHaveLowestSortKeys(new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsTrue(result);
             }
@@ -860,13 +881,15 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand("FR1", null),
-                        0),
+                        0,
+                        null),
                     new ParticipantsForCommand(
                         Organization.ConstructionCompany,
                         null,
                         new PersonForCommand(null, "ola@test.com", true),
                         null,
-                        0)
+                        0,
+                        null)
                 });
                 Assert.IsFalse(result);
             }
@@ -885,7 +908,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(null, "zoey@test.com", true),
                         null,
-                        0);
+                        0,
+                        null);
                 var result = dut.OnlyRequiredParticipantsHaveLowestSortKeys(new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], person });
                 Assert.IsFalse(result);
             }
@@ -904,7 +928,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         new ExternalEmailForCommand("test@email.com", _participantId1),
                         null,
                         null,
-                        3);
+                        3,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(externalPerson, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -923,7 +948,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(null, "zoey@test.com", true, _participantId1),
                         null,
-                        3);
+                        3,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(person, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -942,7 +968,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand("FR1", null, _participantId1),
-                        0);
+                        0,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(functionalRole, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -965,7 +992,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                             new PersonForCommand(null, "zoey1@test.com", false, _participantId2)
                             },
                             _operationCurrentPersonId),
-                        0);
+                        0,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(functionalRole, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -984,7 +1012,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         new ExternalEmailForCommand("test@email.com", 200),
                         null,
                         null,
-                        3);
+                        3,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(externalPerson, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1003,7 +1032,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         new PersonForCommand(null, "zoey@test.com", true, 500),
                         null,
-                        3);
+                        3,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(person, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1022,7 +1052,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new FunctionalRoleForCommand("FR1", null, 400),
-                        0);
+                        0,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(functionalRole, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1045,7 +1076,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                             new PersonForCommand(null, "zoey1@test.com", false, 500)
                             }
                         ),
-                        0);
+                        0,
+                        null);
                 var result = await dut.ParticipantWithIdExistsAsync(functionalRole, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/IPOContextExtension.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/IPOContextExtension.cs
@@ -43,9 +43,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
             var mdpInvitation = SeedMdpInvitation(dbContext, plant);
             knownTestData.MdpInvitationIds.Add(mdpInvitation.Id);
 
-            var attachment = SeedAttachment(dbContext, mdpInvitation);
-            knownTestData.AttachmentIds.Add(attachment.Id);
-
             var comment = SeedComment(dbContext, mdpInvitation);
             knownTestData.CommentIds.Add(comment.Id);
             
@@ -114,14 +111,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
             dbContext.SaveChangesAsync().Wait();
 
             return dpInvitation;
-        }
-
-        private static Attachment SeedAttachment(IPOContext dbContext, Invitation invitation)
-        {
-            var attachment = new Attachment(invitation.Plant, "Fil1.txt");
-            invitation.AddAttachment(attachment);
-            dbContext.SaveChangesAsync().Wait();
-            return attachment;
         }
 
         private static Comment SeedComment(IPOContext dbContext, Invitation invitation)

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -1025,16 +1025,52 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
         [TestMethod]
         public async Task ChangeAttendedStatusOnParticipants_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
-            => await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
-                UserType.Signer,
-                TestFactory.PlantWithAccess,
-                9999,
-                new[] {new ParticipantToChangeDto
-                {
-                    Attended = true, Id = 1, Note = "note", RowVersion = TestFactory.AValidRowVersion
-                }},
-                HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+        {
+            // Arrange
+            var (_, participantToChangeDtos) = await CreateValidParticipantToChangeDtosAsync(_participantsForSigning);
+
+            // Act
+            await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+                           UserType.Signer,
+                           TestFactory.PlantWithAccess,
+                           9999,
+                           participantToChangeDtos,
+                           HttpStatusCode.BadRequest,
+                           "IPO with this ID does not exist!");
+        }
+
+        [TestMethod]
+        public async Task ChangeAttendedStatusOnParticipants_AsSigner_ShouldReturnBadRequest_WhenUnknownParticipantId()
+        {
+            // Arrange
+            var (invitationToChangeId, participantToChangeDtos) = await CreateValidParticipantToChangeDtosAsync(_participantsForSigning);
+            participantToChangeDtos[0].Id = 290690;
+
+            // Act
+            await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+                           UserType.Signer,
+                           TestFactory.PlantWithAccess,
+                           invitationToChangeId,
+                           participantToChangeDtos,
+                           HttpStatusCode.BadRequest,
+                           "Participant with ID does not exist on invitation!");
+        }
+
+        [TestMethod]
+        public async Task ChangeAttendedStatusOnParticipants_AsSigner_ShouldReturnConflict_WhenWrongParticipantRowVersion()
+        {
+            // Arrange
+            var (invitationToChangeId, participantToChangeDtos) = await CreateValidParticipantToChangeDtosAsync(_participantsForSigning);
+            participantToChangeDtos[0].RowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+                           UserType.Signer,
+                           TestFactory.PlantWithAccess,
+                           invitationToChangeId,
+                           participantToChangeDtos,
+                           HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region UploadAttachment

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -319,7 +319,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task EditInvitation_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
         {
-            var (_, editInvitationDto) = await CreateValidEditInvitationDtoAsync();
+            var (_, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participants);
             await InvitationsControllerTestsHelper.EditInvitationAsync(
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
@@ -332,7 +332,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task EditInvitation_AsPlanner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
         {
-            var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync();
+            var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participants);
             editInvitationDto.RowVersion = TestFactory.WrongButValidRowVersion;
             await InvitationsControllerTestsHelper.EditInvitationAsync(
                 UserType.Planner,
@@ -345,7 +345,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task EditInvitation_AsPlanner_ShouldReturnConflict_WhenWrongParticipantRowVersion()
         {
-            var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync();
+            var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participants);
             editInvitationDto.UpdatedParticipants.First().RowVersion = TestFactory.WrongButValidRowVersion;
             await InvitationsControllerTestsHelper.EditInvitationAsync(
                 UserType.Planner,
@@ -410,14 +410,32 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task SignPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId() 
+        public async Task SignPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
             => await InvitationsControllerTestsHelper.SignPunchOutAsync(
                 UserType.Signer,
                 TestFactory.PlantWithAccess,
                 38934,
                 88,
                 TestFactory.AValidRowVersion,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
+
+        [TestMethod]
+        public async Task SignPunchOut_AsSigner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
+        {
+            var (invitationToSignId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participantsForSigning);
+
+            var participant = editInvitationDto.UpdatedParticipants.Single(p => p.Organization == Organization.TechnicalIntegrity);
+
+            // Act
+            var newRowVersion = await InvitationsControllerTestsHelper.SignPunchOutAsync(
+                    UserType.Signer,
+                    TestFactory.PlantWithAccess,
+                    invitationToSignId,
+                    participant.Person.Id,
+                    TestFactory.WrongButValidRowVersion,
+                    HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region Complete
@@ -497,7 +515,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     ParticipantRowVersion = validParticipantForCompleting.RowVersion,
                     Participants = new List<ParticipantToChangeDto>()
                 },
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         }
         #endregion
 
@@ -556,7 +575,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 9999,
                 new UnCompletePunchOutDto(),
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region Accept
@@ -623,7 +643,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 9999,
                 new AcceptPunchOutDto(),
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region UnAccept
@@ -682,7 +703,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 9999,
                 new UnAcceptPunchOutDto(),
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region Cancel
@@ -740,7 +762,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 9999,
                 new CancelPunchOutDto(),
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region ChangeAttendedStatusOnParticipants
@@ -792,7 +815,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 {
                     Attended = true, Id = 1, Note = "note", RowVersion = TestFactory.AValidRowVersion
                 }},
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region UploadAttachment
@@ -841,7 +865,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 9999,
                 FileToBeUploaded,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region DeleteAttachment
@@ -895,7 +920,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 _attachmentId,
                 TestFactory.AValidRowVersion,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "IPO with this ID does not exist!");
         #endregion
 
         #region GetAttachments

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -347,8 +347,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task EditInvitation_AsPlanner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
         {
+            // Arrange
             var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participants);
             editInvitationDto.RowVersion = TestFactory.WrongButValidRowVersion;
+            
+            // Act
             await InvitationsControllerTestsHelper.EditInvitationAsync(
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
@@ -360,8 +363,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task EditInvitation_AsPlanner_ShouldReturnConflict_WhenWrongParticipantRowVersion()
         {
+            // Arrange
             var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participants);
             editInvitationDto.UpdatedParticipants.First().RowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
             await InvitationsControllerTestsHelper.EditInvitationAsync(
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
@@ -427,10 +433,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task SignPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
         {
+            // Arrange
             var (invitationToSignId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participantsForSigning);
-
             var participant = editInvitationDto.UpdatedParticipants.Single(p => p.Organization == Organization.TechnicalIntegrity);
 
+            // Act
             await InvitationsControllerTestsHelper.SignPunchOutAsync(
                            UserType.Signer,
                            TestFactory.PlantWithAccess,
@@ -444,8 +451,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task SignPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownParticipantId()
         {
+            // Arrange
             var (invitationToSignId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participantsForSigning);
-
             var participant = editInvitationDto.UpdatedParticipants.Single(p => p.Organization == Organization.TechnicalIntegrity);
 
             await InvitationsControllerTestsHelper.SignPunchOutAsync(
@@ -461,8 +468,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         [TestMethod]
         public async Task SignPunchOut_AsSigner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
         {
+            // Arrange
             var (invitationToSignId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participantsForSigning);
-
             var participant = editInvitationDto.UpdatedParticipants.Single(p => p.Organization == Organization.TechnicalIntegrity);
 
             // Act
@@ -869,16 +876,53 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 new UnAcceptPunchOutDto(),
                 HttpStatusCode.Forbidden);
 
-
         [TestMethod]
         public async Task UnAcceptPunchOut_AsSigner_ShouldReturnBadRequest_WhenUnknownInvitationId()
-            => await InvitationsControllerTestsHelper.UnAcceptPunchOutAsync(
-                UserType.Signer,
-                TestFactory.PlantWithAccess,
-                9999,
-                new UnAcceptPunchOutDto(),
-                HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+        {
+            // Arrange
+            var (_, unAcceptPunchOutDto) = await CreateValidUnAcceptPunchOutDtoAsync(_participantsForSigning);
+            
+            // Act
+            await InvitationsControllerTestsHelper.UnAcceptPunchOutAsync(
+                           UserType.Signer,
+                           TestFactory.PlantWithAccess,
+                           9999,
+                           unAcceptPunchOutDto,
+                           HttpStatusCode.BadRequest,
+                           "IPO with this ID does not exist!");
+        }
+
+        [TestMethod]
+        public async Task UnAcceptPunchOut_AsSigner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
+        {
+            // Arrange
+            var (invitationToUnAcceptId, unAcceptPunchOutDto) = await CreateValidUnAcceptPunchOutDtoAsync(_participantsForSigning);
+            unAcceptPunchOutDto.InvitationRowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await InvitationsControllerTestsHelper.UnAcceptPunchOutAsync(
+                           UserType.Signer,
+                           TestFactory.PlantWithAccess,
+                           invitationToUnAcceptId,
+                           unAcceptPunchOutDto,
+                           HttpStatusCode.Conflict);
+        }
+
+        [TestMethod]
+        public async Task UnAcceptPunchOut_AsSigner_ShouldReturnConflict_WhenWrongParticipantRowVersion()
+        {
+            // Arrange
+            var (invitationToUnAcceptId, unAcceptPunchOutDto) = await CreateValidUnAcceptPunchOutDtoAsync(_participantsForSigning);
+            unAcceptPunchOutDto.ParticipantRowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await InvitationsControllerTestsHelper.UnAcceptPunchOutAsync(
+                           UserType.Signer,
+                           TestFactory.PlantWithAccess,
+                           invitationToUnAcceptId,
+                           unAcceptPunchOutDto,
+                           HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region Cancel

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -459,7 +459,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 InitialMdpInvitationId);
             var validParticipantForCompleting = _participantsForSigning
-                .Single(p => p.Organization == Organization.Contractor).Person;
+                .Single(p => p.Organization == Organization.Contractor);
 
             await InvitationsControllerTestsHelper.CompletePunchOutAsync(
                 UserType.Signer,

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -1102,7 +1102,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Anonymous,
                 TestFactory.PlantWithAccess,
                 9999,
-                FileToBeUploaded,
+                TestFile.NewFileToBeUploaded(),
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
@@ -1111,7 +1111,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
                 9999,
-                FileToBeUploaded,
+                TestFile.NewFileToBeUploaded(),
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -1121,7 +1121,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Planner,
                 TestFactory.UnknownPlant,
                 9999,
-                FileToBeUploaded,
+                TestFile.NewFileToBeUploaded(),
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -1131,7 +1131,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
                 9999,
-                FileToBeUploaded,
+                TestFile.NewFileToBeUploaded(),
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
@@ -1140,7 +1140,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
                 9999,
-                FileToBeUploaded,
+                TestFile.NewFileToBeUploaded(),
                 HttpStatusCode.BadRequest,
                 "IPO with this ID does not exist!");
         #endregion
@@ -1152,7 +1152,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
                 InitialMdpInvitationId,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -1162,7 +1162,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
                 InitialMdpInvitationId,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -1173,7 +1173,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
                 InitialMdpInvitationId,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -1194,10 +1194,20 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
                 9999,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "IPO with this ID does not exist!");
+
+        [TestMethod]
+        public async Task DeleteAttachment_AsPlanner_ShouldReturnConflict_WhenWrongAttachmentRowVersion()
+            => await InvitationsControllerTestsHelper.DeleteAttachmentAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                InitialMdpInvitationId,
+                _attachmentOnInitialMdpInvitation.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
         #endregion
 
         #region GetAttachments
@@ -1242,7 +1252,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
                 InitialMdpInvitationId,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
@@ -1251,7 +1261,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
                 InitialMdpInvitationId,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -1261,7 +1271,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
                 InitialMdpInvitationId,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
@@ -1270,7 +1280,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
                 12456,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 HttpStatusCode.NotFound);
 
         [TestMethod]
@@ -1279,7 +1289,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
                 12456,
-                _attachmentId,
+                _attachmentOnInitialMdpInvitation.Id,
                 HttpStatusCode.NotFound);
         #endregion
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -975,13 +975,35 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
         [TestMethod]
         public async Task CancelPunchOut_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
-            => await InvitationsControllerTestsHelper.CancelPunchOutAsync(
-                UserType.Planner,
-                TestFactory.PlantWithAccess,
-                9999,
-                new CancelPunchOutDto(),
-                HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+        {
+            // Arrange
+            var (_, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participantsForSigning);
+
+            // Act
+            await InvitationsControllerTestsHelper.CancelPunchOutAsync(
+                           UserType.Planner,
+                           TestFactory.PlantWithAccess,
+                           9999,
+                           cancelPunchOutDto,
+                           HttpStatusCode.BadRequest,
+                           "IPO with this ID does not exist!");
+        }
+
+        [TestMethod]
+        public async Task CancelPunchOut_AsPlanner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
+        {
+            // Arrange
+            var (invitationToCancelId, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participantsForSigning);
+            cancelPunchOutDto.RowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await InvitationsControllerTestsHelper.CancelPunchOutAsync(
+                           UserType.Planner,
+                           TestFactory.PlantWithAccess,
+                           invitationToCancelId,
+                           cancelPunchOutDto,
+                           HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region ChangeAttendedStatusOnParticipants

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -602,6 +602,38 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 new UnCompletePunchOutDto(),
                 HttpStatusCode.BadRequest,
                 "IPO with this ID does not exist!");
+
+        [TestMethod]
+        public async Task UnCompletePunchOut_AsSigner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
+        {
+            // Arrange
+            var (invitationToUnCompleteId, unCompletePunchOutDto) = await CreateValidUnCompletePunchOutDtoAsync(_participantsForSigning);
+            unCompletePunchOutDto.InvitationRowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await InvitationsControllerTestsHelper.UnCompletePunchOutAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                invitationToUnCompleteId,
+                unCompletePunchOutDto,
+                HttpStatusCode.Conflict);
+        }
+
+        [TestMethod]
+        public async Task UnCompletePunchOut_AsSigner_ShouldReturnConflict_WhenWrongParticipantRowVersion()
+        {
+            // Arrange
+            var (invitationToUnCompleteId, unCompletePunchOutDto) = await CreateValidUnCompletePunchOutDtoAsync(_participantsForSigning);
+            unCompletePunchOutDto.ParticipantRowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await InvitationsControllerTestsHelper.UnCompletePunchOutAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                invitationToUnCompleteId,
+                unCompletePunchOutDto,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region Accept

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -326,7 +326,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 38934,
                 editInvitationDto,
                 HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+                "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -445,7 +445,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                            participant.Person.Id,
                            TestFactory.AValidRowVersion,
                            HttpStatusCode.BadRequest,
-                           "IPO with this ID does not exist!");
+                           "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -553,7 +553,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 completePunchOutDto,
                 HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+                "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -669,7 +669,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                            9999,
                            unCompletePunchOutDto,
                            HttpStatusCode.BadRequest,
-                           "IPO with this ID does not exist!");
+                           "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -775,7 +775,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                            9999,
                            acceptPunchOutDto,
                            HttpStatusCode.BadRequest,
-                           "IPO with this ID does not exist!");
+                           "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -889,7 +889,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                            9999,
                            unAcceptPunchOutDto,
                            HttpStatusCode.BadRequest,
-                           "IPO with this ID does not exist!");
+                           "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -986,7 +986,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                            9999,
                            cancelPunchOutDto,
                            HttpStatusCode.BadRequest,
-                           "IPO with this ID does not exist!");
+                           "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -1058,7 +1058,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                            9999,
                            participantToChangeDtos,
                            HttpStatusCode.BadRequest,
-                           "IPO with this ID does not exist!");
+                           "Invitation with this ID does not exist!");
         }
 
         [TestMethod]
@@ -1142,7 +1142,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 9999,
                 TestFile.NewFileToBeUploaded(),
                 HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+                "Invitation with this ID does not exist!");
         #endregion
 
         #region DeleteAttachment
@@ -1197,7 +1197,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 _attachmentOnInitialMdpInvitation.Id,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist!");
+                "Invitation with this ID does not exist!");
 
         [TestMethod]
         public async Task DeleteAttachment_AsPlanner_ShouldReturnConflict_WhenWrongAttachmentRowVersion()
@@ -1341,7 +1341,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 123456,
                 "comment",
                 HttpStatusCode.BadRequest,
-                "IPO with this ID does not exist");
+                "Invitation with this ID does not exist");
         #endregion
 
         #region GetHistory

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -507,28 +507,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         public async Task CancelPunchOut_AsPlanner_ShouldCancelPunchOut()
         {
             // Arrange
-            var invitationToCancelId = await InvitationsControllerTestsHelper.CreateInvitationAsync(
-                UserType.Planner,
-                TestFactory.PlantWithAccess,
-                "InvitationForCancelTitle",
-                "InvitationForCancelDescription",
-                InvitationLocation,
-                DisciplineType.DP,
-                _invitationStartTime,
-                _invitationEndTime,
-                _participantsForSigning,
-                _mcPkgScope,
-                null
-            );
+            var (invitationToCancelId, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participantsForSigning);
 
-            var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Planner,
-                TestFactory.PlantWithAccess,
-                invitationToCancelId);
-            var cancelPunchOutDto = new CancelPunchOutDto
-            {
-                RowVersion = invitation.RowVersion
-            };
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.CancelPunchOutAsync(
                 UserType.Planner,
@@ -543,7 +523,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 invitationToCancelId);
 
             Assert.AreEqual(IpoStatus.Canceled, canceledInvitation.Status);
-            AssertRowVersionChange(invitation.RowVersion, newRowVersion);
+            AssertRowVersionChange(cancelPunchOutDto.RowVersion, newRowVersion);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -106,34 +106,16 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         public async Task SignPunchOut_AsSigner_ShouldSignPunchOut()
         {
             // Arrange
-            var invitationToSignId = await InvitationsControllerTestsHelper.CreateInvitationAsync(
-                UserType.Planner,
-                TestFactory.PlantWithAccess,
-                "InvitationForSigningTitle",
-                "InvitationForSigningDescription",
-                InvitationLocation,
-                DisciplineType.DP,
-                _invitationStartTime,
-                _invitationEndTime,
-                _participantsForSigning,
-                _mcPkgScope,
-                null
-            );
+            var (invitationToSignId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participantsForSigning);
 
-            var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Signer,
-                TestFactory.PlantWithAccess,
-                invitationToSignId);
-
-            var participant = invitation.Participants
-                .Single(p => p.Organization == Organization.TechnicalIntegrity);
+            var participant = editInvitationDto.UpdatedParticipants.Single(p => p.Organization == Organization.TechnicalIntegrity);
 
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.SignPunchOutAsync(
                     UserType.Signer,
                     TestFactory.PlantWithAccess,
                     invitationToSignId,
-                    participant.Person.Person.Id,
+                    participant.Person.Id,
                     participant.RowVersion);
 
             // Assert
@@ -142,10 +124,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 TestFactory.PlantWithAccess,
                 invitationToSignId);
 
-            var signerParticipant = signedInvitation.Participants.Single(p => p.Person?.Person.Id == participant.Person.Person.Id);
+            var signerParticipant = signedInvitation.Participants.Single(p => p.Person?.Person.Id == participant.Person.Id);
             Assert.IsNotNull(signerParticipant.SignedAtUtc);
             Assert.AreEqual(_sigurdSigner.Oid, signerParticipant.SignedBy.AzureOid.ToString());
-            AssertRowVersionChange(invitation.RowVersion, newRowVersion);
+            AssertRowVersionChange(editInvitationDto.RowVersion, newRowVersion);
         }
 
         [TestMethod]
@@ -622,7 +604,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         public async Task EditInvitation_AsPlanner_ShouldEditInvitation()
         {
             // Arrange
-            var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync();
+            var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(_participants);
 
             var currentRowVersion = editInvitationDto.RowVersion;
             const string UpdatedTitle = "UpdatedInvitationTitle";

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -358,7 +358,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
                 InitialMdpInvitationId,
-                FileToBeUploaded);
+                TestFile.NewFileToBeUploaded());
 
             // Assert
             invitationAttachments = InvitationsControllerTestsHelper.GetAttachmentsAsync(
@@ -404,7 +404,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             Assert.IsNotNull(attachmentDtos);
             Assert.IsTrue(attachmentDtos.Count > 0);
 
-            var invitationAttachment = attachmentDtos.Single(a => a.Id == _attachmentId);
+            var invitationAttachment = attachmentDtos.Single(a => a.Id == _attachmentOnInitialMdpInvitation.Id);
             Assert.IsNotNull(invitationAttachment.FileName);
             Assert.IsNotNull(invitationAttachment.RowVersion);
         }
@@ -413,17 +413,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         public async Task DeleteAttachment_AsPlanner_ShouldDeleteAttachment()
         {
             // Arrange
-            await InvitationsControllerTestsHelper.UploadAttachmentAsync(
-                UserType.Planner,
-                TestFactory.PlantWithAccess,
-                InitialMdpInvitationId,
-                FileToBeUploaded2);
-
-            var attachmentDtos = await InvitationsControllerTestsHelper.GetAttachmentsAsync(
-                UserType.Viewer,
-                TestFactory.PlantWithAccess,
-                InitialMdpInvitationId);
-            var attachment = attachmentDtos.Single(t => t.FileName == FileToBeUploaded2.FileName);
+            var attachment = await UploadAttachmentAsync(InitialMdpInvitationId);
 
             // Act
             await InvitationsControllerTestsHelper.DeleteAttachmentAsync(
@@ -434,7 +424,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 attachment.RowVersion);
 
             // Assert
-            attachmentDtos = await InvitationsControllerTestsHelper.GetAttachmentsAsync(
+            var attachmentDtos = await InvitationsControllerTestsHelper.GetAttachmentsAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
                 InitialMdpInvitationId);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -236,7 +236,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 .Returns(new MeetingOptions{PcsBaseUrl = TestFactory.PlantWithAccess});
         }
 
-        internal async Task<(int, EditInvitationDto)> CreateValidEditInvitationDtoAsync()
+        internal async Task<(int, EditInvitationDto)> CreateValidEditInvitationDtoAsync(IList<ParticipantsForCommand> participants)
         {
             var id = await InvitationsControllerTestsHelper.CreateInvitationAsync(
                 UserType.Planner,
@@ -247,7 +247,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 DisciplineType.DP,
                 _invitationStartTime,
                 _invitationEndTime,
-                _participants,
+                participants,
                 _mcPkgScope,
                 null);
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -436,6 +436,34 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             return (id, editInvitationDto);
         }
 
+        internal async Task<(int, CancelPunchOutDto)> CreateValidCancelPunchOutDtoAsync(List<ParticipantsForCommand> participants)
+        {
+            var id = await InvitationsControllerTestsHelper.CreateInvitationAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                InvitationLocation,
+                DisciplineType.DP,
+                _invitationStartTime,
+                _invitationEndTime,
+                participants,
+                _mcPkgScope,
+                null);
+
+            var invitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
+                UserType.Viewer,
+                TestFactory.PlantWithAccess,
+                id);
+
+            var cancelPunchOutDto = new CancelPunchOutDto
+            {
+                RowVersion = invitation.RowVersion
+            };
+
+            return (id, cancelPunchOutDto);
+        }
+
         private IEnumerable<ParticipantDtoEdit> ConvertToParticipantDtoEdit(IEnumerable<ParticipantDtoGet> participants)
         {
             var editVersionParticipantDtos = new List<ParticipantDtoEdit>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -236,6 +236,33 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 .Returns(new MeetingOptions{PcsBaseUrl = TestFactory.PlantWithAccess});
         }
 
+        internal async Task<(int, UnAcceptPunchOutDto)> CreateValidUnAcceptPunchOutDtoAsync(List<ParticipantsForCommand> participants)
+        {
+            var (invitationToAcceptId, acceptPunchOutDto) = await CreateValidAcceptPunchOutDtoAsync(participants);
+
+            await InvitationsControllerTestsHelper.AcceptPunchOutAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                invitationToAcceptId,
+                acceptPunchOutDto);
+
+            var acceptedInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
+                UserType.Signer,
+                TestFactory.PlantWithAccess,
+                invitationToAcceptId);
+
+            var accepterParticipant = acceptedInvitation.Participants
+                .Single(p => p.Organization == Organization.ConstructionCompany);
+
+            var unAcceptPunchOutDto = new UnAcceptPunchOutDto
+            {
+                InvitationRowVersion = acceptedInvitation.RowVersion,
+                ParticipantRowVersion = accepterParticipant.RowVersion,
+            };
+
+            return (invitationToAcceptId, unAcceptPunchOutDto);
+        }
+
         internal async Task<(int, AcceptPunchOutDto)> CreateValidAcceptPunchOutDtoAsync(List<ParticipantsForCommand> participants)
         {
             var (invitationToCompleteAndAcceptId, completePunchOutDto) = await CreateValidCompletePunchOutDtoAsync(participants);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -56,13 +56,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     null,
                     null,
                     functionalRoleParticipant,
-                    0),
+                    0,
+                    null),
                 new ParticipantsForCommand(
                     Organization.ConstructionCompany,
                     null,
                     personParticipant,
                     null,
-                    1)
+                    1,
+                    null)
             };
 
             _participantsForSigning = new List<ParticipantsForCommand>
@@ -72,19 +74,22 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     null,
                     _sigurdSigner.AsPersonForCommand(true),
                     null,
-                    0),
+                    0,
+                    null),
                 new ParticipantsForCommand(
                     Organization.ConstructionCompany,
                     null,
                     _sigurdSigner.AsPersonForCommand(true),
                     null,
-                    1),
+                    1,
+                    null),
                 new ParticipantsForCommand(
                     Organization.TechnicalIntegrity,
                     null,
                     _sigurdSigner.AsPersonForCommand(false),
                     null,
-                    2)
+                    2,
+                    null)
             };
 
             var knownGeneralMeeting = new ApiGeneralMeeting

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/ParticipantDtoEdit.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/ParticipantDtoEdit.cs
@@ -9,5 +9,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         public ExternalEmailDto ExternalEmail { get; set; }
         public PersonDto Person { get; set; }
         public FunctionalRoleDto FunctionalRole { get; set; }
+        public string RowVersion { get; set; }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/ParticipantDtoGet.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/ParticipantDtoGet.cs
@@ -14,5 +14,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         public ExternalEmailDto ExternalEmail { get; set; }
         public InvitedPersonDto Person { get; set; }
         public FunctionalRoleDto FunctionalRole { get; set; }
+        public string RowVersion { set; get; }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/PersonDto.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/PersonDto.cs
@@ -5,7 +5,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
     public class PersonDto
     { 
         public int Id { get; set; }
-        public string RowVersion { get; set; }
         public Guid AzureOid { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/KnownTestData.cs
@@ -17,7 +17,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
 
         public List<int> MdpInvitationIds = new List<int>();
         public List<int> DpInvitationIds = new List<int>();
-        public List<int> AttachmentIds = new List<int>();
         public List<int> CommentIds = new List<int>();
         public List<int> McPkgIds = new List<int>();
         public List<int> CommPkgIds = new List<int>();

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTests.cs
@@ -33,20 +33,20 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Me
                 TestFactory.PlantWithAccess,
                 invitationId);
 
-            var completerPerson = invitation.Participants
-                .Single(p => p.Organization == Organization.Contractor).Person;
+            var completerParticipant = invitation.Participants
+                .Single(p => p.Organization == Organization.Contractor);
 
             var completePunchOutDto = new CompletePunchOutDto
             {
                 InvitationRowVersion = invitation.RowVersion,
-                ParticipantRowVersion = completerPerson.Person.RowVersion,
+                ParticipantRowVersion = completerParticipant.RowVersion,
                 Participants = new List<ParticipantToChangeDto>
                 {
                     new ParticipantToChangeDto
                     {
-                        Id = completerPerson.Person.Id,
+                        Id = completerParticipant.Person.Person.Id,
                         Note = "Some note about the punch out round or attendee",
-                        RowVersion = completerPerson.Person.RowVersion,
+                        RowVersion = completerParticipant.RowVersion,
                         Attended = true
                     }
                 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTestsBase.cs
@@ -45,19 +45,22 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Me
                     null,
                     _sigurdSigner.AsPersonForCommand(true),
                     null,
-                    0),
+                    0,
+                    null),
                 new ParticipantsForCommand(
                     Organization.ConstructionCompany,
                     null,
                     _sigurdSigner.AsPersonForCommand(true),
                     null,
-                    1),
+                    1,
+                    null),
                 new ParticipantsForCommand(
                     Organization.TechnicalIntegrity,
                     null,
                     _sigurdSigner.AsPersonForCommand(false),
                     null,
-                    2)
+                    2,
+                    null)
             };
 
             const string McPkgNo = "MC1";

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
@@ -99,12 +99,13 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                1,
+                9876,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString(),
                 false,
                 TestFactory.AValidRowVersion,
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "Saved filter with this ID does not exist!");
 
         [TestMethod]
         public async Task UpdateSavedFilter_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,8 +14,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
-                "title",
-                "criteria",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 true,
                 HttpStatusCode.Unauthorized);
 
@@ -23,8 +24,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
-                "title",
-                "criteria",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 true,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -34,8 +35,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
-                "title",
-                "criteria",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 true,
                 HttpStatusCode.Forbidden);
         #endregion
@@ -73,11 +74,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             => await PersonsControllerTestsHelper.UpdateSavedFilter(
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
-                "new title",
-                "new criteria",
-                false,
-                "cm93VmVyc2lvbg==",
                 1,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
@@ -85,11 +86,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             => await PersonsControllerTestsHelper.UpdateSavedFilter(
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
-                "new title",
-                "new criteria",
-                false,
-                "cm93VmVyc2lvbg==",
                 1,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -98,11 +99,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             await PersonsControllerTestsHelper.UpdateSavedFilter(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                "new title",
-                "new criteria",
+                1,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 false,
-                "cm93VmVyc2lvbg==",
-                9999,
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest);
 
         [TestMethod]
@@ -110,12 +111,34 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             => await PersonsControllerTestsHelper.UpdateSavedFilter(
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
-                "new title",
-                "new criteria",
-                false,
-                "cm93VmVyc2lvbg==",
                 1,
+                 Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+               false,
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsViewer_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var id = await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Viewer,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                true);
+
+            // Act
+            await PersonsControllerTestsHelper.UpdateSavedFilter(
+                UserType.Viewer,
+                TestFactory.PlantWithAccess,
+                1,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region DeleteSavedFilter
@@ -125,7 +148,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
                 1,
-                "AAAAAAAAABA=",
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
@@ -134,7 +157,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
                 1,
-                "AAAAAAAAABA=",
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -144,7 +167,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
                 1,
-                "AAAAAAAAABA=",
+                TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
         #endregion
     }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
@@ -71,7 +71,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
         #region UpdateSavedFilter
         [TestMethod]
         public async Task UpdateSavedFilter_AsAnonymous_ShouldReturnUnauthorized()
-            => await PersonsControllerTestsHelper.UpdateSavedFilter(
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
                 1,
@@ -83,7 +83,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
         [TestMethod]
         public async Task UpdateSavedFilter_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
-            => await PersonsControllerTestsHelper.UpdateSavedFilter(
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
                 1,
@@ -96,7 +96,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
         [TestMethod]
         public async Task UpdateSavedFilter_AsViewer_ShouldReturnBadRequest_WhenUnknownId() =>
-            await PersonsControllerTestsHelper.UpdateSavedFilter(
+            await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
                 1,
@@ -108,7 +108,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
         [TestMethod]
         public async Task UpdateSavedFilter_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
-            => await PersonsControllerTestsHelper.UpdateSavedFilter(
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
                 1,
@@ -129,10 +129,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 true);
 
             // Act
-            await PersonsControllerTestsHelper.UpdateSavedFilter(
+            await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                1,
+                id,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString(),
                 false,
@@ -169,6 +169,25 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 1,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsViewer_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var id = await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Viewer,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                true);
+
+            // Act
+            await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Viewer,
+                TestFactory.PlantWithAccess,
+                id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
@@ -86,7 +86,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             var newTitle = Guid.NewGuid().ToString();
             var newCriteria = Guid.NewGuid().ToString();
             // Act
-            await PersonsControllerTestsHelper.UpdateSavedFilter(
+            await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
                 savedFilter.Id,

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
@@ -1,4 +1,5 @@
-﻿﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,11 +12,13 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
         public async Task CreateSavedFilter_AsViewer_ShouldSaveFilter()
         {
             // Act
+            var title = Guid.NewGuid().ToString();
+            var criteria = Guid.NewGuid().ToString();
             var id = await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                "test title",
-                "criteria",
+                title,
+                criteria,
                 true);
 
             var savedFilters = await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
@@ -30,25 +33,25 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             Assert.IsTrue(id > 0);
             Assert.IsTrue(savedFilters.Count > 0);
             Assert.IsNotNull(savedFilter);
-            Assert.AreEqual(savedFilter.Title, "test title");
-            Assert.AreEqual(savedFilter.Criteria, "criteria");
+            Assert.AreEqual(title, savedFilter.Title);
+            Assert.AreEqual(criteria, savedFilter.Criteria);
         }
 
         [TestMethod]
         public async Task GetSavedFiltersInProject_AsViewer_ShouldGetFilters()
         {
-            var id1 = await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+            var id = await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                "filter1",
-                "criteria",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 true);
 
             await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                "filter2",
-                "criteria",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 true);
 
             // Act
@@ -58,22 +61,19 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 null);
 
             // Assert
-            var savedFilter = savedFilters.Single(sf => sf.Id == id1);
+            var savedFilter = savedFilters.Single(sf => sf.Id == id);
             Assert.IsTrue(savedFilters.Count >= 2);
             Assert.IsNotNull(savedFilter);
-            Assert.AreEqual("filter1", savedFilter.Title);
-            Assert.AreEqual("criteria", savedFilter.Criteria);
         }
 
         [TestMethod]
         public async Task UpdateSavedFilter_AsViewer_ShouldUpdateFilter()
         {
-            // Act
             var id = await PersonsControllerTestsHelper.CreateSavedFilterAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                "filter to update",
-                "criteria to update",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 true);
 
             var savedFilters = await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
@@ -83,15 +83,19 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
             var savedFilter = savedFilters.Single(sf => sf.Id == id);
 
+            var newTitle = Guid.NewGuid().ToString();
+            var newCriteria = Guid.NewGuid().ToString();
+            // Act
             await PersonsControllerTestsHelper.UpdateSavedFilter(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                "new title",
-                "new criteria",
+                savedFilter.Id,
+                newTitle,
+                newCriteria,
                 true,
-                savedFilter.RowVersion,
-                savedFilter.Id);
+                savedFilter.RowVersion);
 
+            // Assert
             var updatedFilters = await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
@@ -99,11 +103,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
             var updatedFilter = updatedFilters.Single(sf => sf.Id == id);
 
-            // Assert
             Assert.IsNotNull(updatedFilter);
             Assert.AreNotEqual(updatedFilter.RowVersion, savedFilter.RowVersion);
-            Assert.AreEqual("new title", updatedFilter.Title);
-            Assert.AreEqual("new criteria", updatedFilter.Criteria);
+            Assert.AreEqual(newTitle, updatedFilter.Title);
+            Assert.AreEqual(newCriteria, updatedFilter.Criteria);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
@@ -66,7 +66,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
             return JsonConvert.DeserializeObject<List<SavedFilterDto>>(jsonString);
         }
 
-        public static async Task<string> UpdateSavedFilter(
+        public static async Task<string> UpdateSavedFilterAsync(
             UserType userType,
             string plant,
             int savedFilterId,
@@ -84,7 +84,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
                 DefaultFilter = defaultFilter,
                 RowVersion = rowVersion
             };
-
 
             var serializePayload = JsonConvert.SerializeObject(bodyPayload);
             var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
@@ -69,11 +69,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
         public static async Task<string> UpdateSavedFilter(
             UserType userType,
             string plant,
+            int savedFilterId,
             string newTitle,
             string newCriteria,
             bool defaultFilter,
             string rowVersion,
-            int id,
             HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
             string expectedMessageOnBadRequest = null)
         {
@@ -88,7 +88,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons
 
             var serializePayload = JsonConvert.SerializeObject(bodyPayload);
             var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
-            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{Route}/SavedFilters/{id}", content);
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{Route}/SavedFilters/{savedFilterId}", content);
 
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -68,6 +68,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         public static string ProjectWithAccess => KnownTestData.ProjectName;
         public static string ProjectWithoutAccess => "Project999";
         public static string AValidRowVersion => "AAAAAAAAAAA=";
+        public static string WrongButValidRowVersion => "AAAAAAAAAAA=";
 
         public KnownTestData KnownTestData { get; }
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFile.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFile.cs
@@ -32,5 +32,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
             multipartContent.Add(bytes, parameterName, FileName);
             return multipartContent;
         }
+
+        public static TestFile NewFileToBeUploaded()
+        {
+            var content = Guid.NewGuid().ToString("B");
+            return new TestFile(content, $"{content}.txt");
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/appsettings.json
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/appsettings.json
@@ -18,6 +18,7 @@
     "PermissionCacheMinutes": 20,
     "PlantCacheMinutes": 20
   },
+  "IsOptimisticConcurrenyEnabled": true,
   "Synchronization": {
     "UserOid": "00000000-0000-0000-0000-000000000000",
     "Interval": "24:0:0"


### PR DESCRIPTION
[AB#88613](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/88613)

NB! Leatest commit https://github.com/equinor/procosys-invitation-for-punch-out-api/pull/163/commits/1ae1ca11270beeb341d3a61382d68ef3c0ff2ff3: HACK to be able to use IsOptimisticConcurrenyEnabled true/false in IPOContext. Misused plantprovider to avoid changing 100+ constructions of IPOContext.
This commit shall be reverted after fix in frontend