### PR TITLE
Make sure IPO bus handling uses correct user id

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Authentication/AuthenticatorOptions.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Authentication/AuthenticatorOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Equinor.ProCoSys.IPO.WebApi.Authentication
+﻿using System;
+
+namespace Equinor.ProCoSys.IPO.WebApi.Authentication
 {
     public class AuthenticatorOptions
     {
@@ -6,6 +8,7 @@
 
         public string IPOApiClientId { get; set; }
         public string IPOApiSecret { get; set; }
+        public Guid IpoApiObjectId { get; set; }
 
         public string MainApiScope { get; set; }
 

--- a/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.IPO.WebApi/appsettings.json
@@ -10,6 +10,7 @@
     "MainApiScope": "",
     "LibraryApiScope": "",
     "IpoApiClientId": "",
+    "IpoApiObjectId": "",
     "IpoApiSecret": ""
   },
   "BlobStorage": {
@@ -59,9 +60,9 @@
     "Enable": false,
     "EnableInDevelopment": false,
     "LeaderElectorUrl": "",
-    "LeaderElectorRenewLeaseInterval": "60000"
+    "LeaderElectorRenewLeaseInterval": "60000",
+    "TopicNames": "ipo"
   },
-  "ServiceBus:TopicNames": "ipo",
   "FusionRequestTimeout": 110,
   "FusionTotalTimeout": 100,
   "Email": {

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/appsettings.json
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Authenticator": {
-    "IPOApiSecret": "abcdefgh"
+    "IPOApiSecret": "abcdefgh",
+    "IpoApiObjectId": "00000000-0000-0000-0000-000000000000"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Running IPO Api requires IpoApiObjectId user when saving changes from library topic.

Before complete of PR:
Add sync user to IPO databases (Dev, Test and Prod)
Add Authenticator:IpoApiObjectId to app configuration (Dev, Test and Prod)

After complete of PR:
Remove  from App Configuration (Dev, Test and Prod)
Synchronization:UserOid
Synchronization:Interval






