### PR TITLE
88968 - Remove temporary code used in concurrency bugfix

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Domain/IPlantProvider.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/IPlantProvider.cs
@@ -3,10 +3,5 @@
     public interface IPlantProvider
     {
         string Plant { get; }
-
-        // HACK To be removed after bugfixed optimistic concurreny
-        // This prop is misplaced here since this interface is alredt injected into IPOContext where needed.
-        // This to not break 100+ constructions of IPOContext in tests
-        bool IsOptimisticConcurrenyEnabled_HACK { get; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/IPOContext.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/IPOContext.cs
@@ -96,10 +96,6 @@ namespace Equinor.ProCoSys.IPO.Infrastructure
 
         private void UpdateConcurrencyToken()
         {
-            if (!_plantProvider.IsOptimisticConcurrenyEnabled_HACK)
-            {
-                return;
-            }
             var modifiedEntries = ChangeTracker
                 .Entries<EntityBase>()
                 .Where(x => x.State == EntityState.Modified || x.State == EntityState.Deleted);

--- a/src/Equinor.ProCoSys.IPO.WebApi/Misc/PlantProvider.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Misc/PlantProvider.cs
@@ -11,9 +11,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Misc
 
         public string Plant { get; private set; }
 
-        public bool IsOptimisticConcurrenyEnabled_HACK
-            => _configuration.GetValue("IsOptimisticConcurrenyEnabled", false);
-
         public void SetPlant(string plant) => Plant = plant;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Seeding/SeedingPlantProvider.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Seeding/SeedingPlantProvider.cs
@@ -8,8 +8,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Seeding
 
         public string Plant { get; }
 
-        public bool IsOptimisticConcurrenyEnabled_HACK => throw new System.NotImplementedException();
-
         public void SetTemporaryPlant(string plant) => throw new System.NotImplementedException();
         public void ReleaseTemporaryPlant() => throw new System.NotImplementedException();
     }


### PR DESCRIPTION
[AB#88968](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/88968)

Don't merge before [AB#88664](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/88664) is deployed and verified in prod