### PR TITLE
87190 - Allow users that are members of Functional Role for Contractor in an …

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidator.cs
@@ -36,7 +36,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
                 => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);
 
             async Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(invitationId, cancellationToken);
+                => await invitationValidator.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(invitationId, cancellationToken);
 
             async Task<bool> InvitationIsNotCanceled(int invitationId, CancellationToken cancellationToken)
                 => !await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Canceled, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidator.cs
@@ -25,9 +25,9 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
                 .MustAsync((command, cancellationToken) => InvitationIsNotAccepted(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
                     $"IPO is in accepted stage! Id={command.InvitationId}")
-                .MustAsync((command, cancellationToken) => CurrentUserIsCreatorOfInvitation(command.InvitationId, cancellationToken))
+                .MustAsync((command, cancellationToken) => CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    $"Current user is not the creator of the invitation! Id={command.InvitationId}")
+                    $"Current user is not the creator of the invitation and not in Contractor Functional Role! Id={command.InvitationId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command =>
                     $"Invitation does not have valid rowVersion! RowVersion={command.RowVersion}");
@@ -35,8 +35,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
             async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);
 
-            async Task<bool> CurrentUserIsCreatorOfInvitation(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.CurrentUserIsCreatorOfInvitation(invitationId, cancellationToken);
+            async Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(invitationId, cancellationToken);
 
             async Task<bool> InvitationIsNotCanceled(int invitationId, CancellationToken cancellationToken)
                 => !await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Canceled, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
@@ -24,7 +24,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
         Task<bool> IpoHasAccepterAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SignerExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
         Task<bool> ValidSigningParticipantExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
-        Task<bool> CurrentUserIsCreatorOfInvitation(int invitationId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(int invitationId, CancellationToken cancellationToken);
         Task<bool> SameUserUnCompletingThatCompletedAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SameUserUnAcceptingThatAcceptedAsync(int invitationId, CancellationToken cancellationToken);
     }

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
@@ -24,7 +24,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
         Task<bool> IpoHasAccepterAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SignerExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
         Task<bool> ValidSigningParticipantExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
-        Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(int invitationId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SameUserUnCompletingThatCompletedAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SameUserUnAcceptingThatAcceptedAsync(int invitationId, CancellationToken cancellationToken);
     }

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
@@ -341,14 +341,14 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
             else
             {
                 // allow if user is member of contractor functional role
-                var participants = await (from participant in _context.QuerySet<Participant>()
+                var contractorParticipants = await (from participant in _context.QuerySet<Participant>()
                                           where EF.Property<int>(participant, "InvitationId") == invitationId &&
                                                 participant.Organization == Organization.Contractor
                                           select participant).ToListAsync(cancellationToken);
 
-                if (participants.Any(p => p.FunctionalRoleCode != null))
+                if (contractorParticipants.Any(p => p.FunctionalRoleCode != null))
                 {
-                    var contractorCode = participants.First().FunctionalRoleCode;
+                    var contractorCode = contractorParticipants.First().FunctionalRoleCode;
                     var person = await _personApiService.GetPersonInFunctionalRoleAsync(
                                _plantProvider.Plant,
                                currentUserOid.ToString(),

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
@@ -320,7 +320,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
             return acceptingPerson != null && _currentUserProvider.GetCurrentUserOid() == acceptingPerson.Oid;
         }
 
-        public async Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(int invitationId, CancellationToken cancellationToken)
+        public async Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(int invitationId, CancellationToken cancellationToken)
         {
             var currentUserOid = _currentUserProvider.GetCurrentUserOid();
 
@@ -348,13 +348,13 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
 
                 if (participants.Any(p => p.FunctionalRoleCode != null))
                 {
+                    var contractorCode = participants.First().FunctionalRoleCode;
                     var person = await _personApiService.GetPersonInFunctionalRoleAsync(
                                _plantProvider.Plant,
                                currentUserOid.ToString(),
-                               participants.FirstOrDefault().FunctionalRoleCode);
+                               contractorCode);
 
-                    return person != null;
-
+                    return person != null && new Guid(person.AzureOid) == currentUserOid;
                 }
                 return false;
             };

--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
@@ -388,11 +388,6 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
                 throw new ArgumentNullException(nameof(caller));
             }
 
-            if (caller.Id != CreatedById)
-            {
-                throw new InvalidOperationException("Only the creator can cancel an invitation");
-            }
-
             if (Status == IpoStatus.Canceled)
             {
                 throw new Exception($"{nameof(Invitation)} {Id} is already canceled");

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
@@ -166,7 +166,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => state(v, t)),
                     It.IsAny<Exception>(),
-                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)));
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
@@ -115,7 +115,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             var result = await _dut.Handle(_command, default);
 
             Assert.AreEqual(IpoStatus.Canceled, _invitation.Status);
-            Assert.AreEqual(result.ResultType, ServiceResult.ResultType.Ok);
+            Assert.AreEqual(ServiceResult.ResultType.Ok, result.ResultType);
 
             _fusionMeetingClient.Verify(f => f.DeleteMeetingAsync(_invitation.MeetingId), Times.Once);
             _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -132,7 +132,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
             Assert.AreEqual(_invitationRowVersion, result.Data);
             Assert.AreEqual(_invitationRowVersion, _invitation.RowVersion.ConvertToString());
-            Assert.AreEqual(result.ResultType, ServiceResult.ResultType.Ok);
+            Assert.AreEqual(ServiceResult.ResultType.Ok, result.ResultType);
         }
 
         [TestMethod]
@@ -147,7 +147,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             // Assert
             Assert.AreEqual(2, _invitation.PostSaveDomainEvents.Count);
             Assert.AreEqual(typeof(IpoCanceledEvent), _invitation.PostSaveDomainEvents.Last().GetType());
-            Assert.AreEqual(result.ResultType, ServiceResult.ResultType.Ok);
+            Assert.AreEqual(ServiceResult.ResultType.Ok, result.ResultType);
         }
 
         [TestMethod]
@@ -163,7 +163,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             // Assert
             Func<object, Type, bool> state = (v, t) => v.ToString().CompareTo("Unable to cancel outlook meeting for IPO.") == 0;
 
-            Assert.AreEqual(result.ResultType, ServiceResult.ResultType.Ok);
+            Assert.AreEqual(ServiceResult.ResultType.Ok, result.ResultType);
 
             _loggerMock.Verify(
                 x => x.Log(

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.IPO.Domain.Events.PostSave;
 using Fusion.Integration.Meeting;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -23,6 +24,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IFusionMeetingClient> _fusionMeetingClient;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
+        private Mock<ILogger<CancelPunchOutCommandHandler>> _loggerMock;
 
         private CancelPunchOutCommand _command;
         private CancelPunchOutCommandHandler _dut;
@@ -49,6 +51,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _currentUserProviderMock
                 .Setup(x => x.GetCurrentUserOid()).Returns(_azureOidForCurrentUser);
+
+            _loggerMock = new Mock<ILogger<CancelPunchOutCommandHandler>>();
+
 
             var currentPerson = new Person(_azureOidForCurrentUser, null, null, null, null);
             _personRepositoryMock = new Mock<IPersonRepository>();
@@ -97,7 +102,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
                 _personRepositoryMock.Object,
                 _unitOfWorkMock.Object,
                 _fusionMeetingClient.Object,
-                _currentUserProviderMock.Object);
+                _currentUserProviderMock.Object,
+                _loggerMock.Object
+                );
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
@@ -155,7 +155,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
                 .Throws(new MeetingApiException(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.Forbidden), ""));
                         
             // Act
-            var result = await _dut.Handle(_command, default);
+            await _dut.Handle(_command, default);
 
             // Assert
             Func<object, Type, bool> state = (v, t) => v.ToString().CompareTo("Unable to cancel outlook meeting for IPO.") == 0;

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidatorTests.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_invitationRowVersion)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_id, default)).Returns(Task.FromResult(true));
             _command = new CancelPunchOutCommand(_id, _invitationRowVersion);
 
             _dut = new CancelPunchOutCommandValidator(_invitationValidatorMock.Object, _rowVersionValidatorMock.Object);
@@ -91,7 +91,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenUserTryingToCancelIsNotOrganizerOfIpo()
         {
-            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandValidatorTests.cs
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_invitationRowVersion)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOfInvitation(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_id, default)).Returns(Task.FromResult(true));
             _command = new CancelPunchOutCommand(_id, _invitationRowVersion);
 
             _dut = new CancelPunchOutCommandValidator(_invitationValidatorMock.Object, _rowVersionValidatorMock.Object);
@@ -91,13 +91,13 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenUserTryingToCancelIsNotOrganizerOfIpo()
         {
-            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOfInvitation(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Current user is not the creator of the invitation!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Current user is not the creator of the invitation and not in Contractor Functional Role!"));
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -81,17 +81,17 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-             var invitationWithCurrentUserAsParticipants = new Invitation(
-                    TestPlant,
-                    _projectName,
-                    _title1,
-                    _description,
-                    _typeDp,
-                    new DateTime(),
-                    new DateTime(),
-                    null,
-                    new List<McPkg> { new McPkg(TestPlant, _projectName, "Comm", "Mc", "d", "1|2")},
-                    null);
+                var invitationWithCurrentUserAsParticipants = new Invitation(
+                       TestPlant,
+                       _projectName,
+                       _title1,
+                       _description,
+                       _typeDp,
+                       new DateTime(),
+                       new DateTime(),
+                       null,
+                       new List<McPkg> { new McPkg(TestPlant, _projectName, "Comm", "Mc", "d", "1|2") },
+                       null);
 
                 foreach (var attachment in _attachments)
                 {
@@ -159,7 +159,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                     new DateTime(),
                     new DateTime(),
                     null,
-                    new List<McPkg> { new McPkg(TestPlant, _projectName, "Comm", "Mc", "d", "1|2")},
+                    new List<McPkg> { new McPkg(TestPlant, _projectName, "Comm", "Mc", "d", "1|2") },
                     null);
                 context.Invitations.Add(invitationWithFrAsParticipants);
                 _invitationIdWithFrAsParticipants = invitationWithFrAsParticipants.Id;
@@ -462,7 +462,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
-                var result = dut.IsValidScope(_typeDp,new List<string>(), new List<string>());
+                var result = dut.IsValidScope(_typeDp, new List<string>(), new List<string>());
                 Assert.IsFalse(result);
             }
         }
@@ -711,10 +711,10 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                     null,
                     null,
                     new InvitedFunctionalRoleForEditCommand(
-                        null, 
+                        null,
                         "FR",
-                        new List<InvitedPersonForEditCommand>{ new InvitedPersonForEditCommand(null, new Guid("11111111-2222-2222-2222-333333333333"), "", true, null)},
-                        null), 
+                        new List<InvitedPersonForEditCommand> { new InvitedPersonForEditCommand(null, new Guid("11111111-2222-2222-2222-333333333333"), "", true, null) },
+                        null),
                     3);
                 var result = dut.IsValidParticipantList(
                     new List<ParticipantsForCommand> { _participantsOnlyRequired[0], _participantsOnlyRequired[1], fr });
@@ -967,8 +967,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new InvitedFunctionalRoleForEditCommand(
-                            _operationCurrentPersonId, 
-                            "FR1", 
+                            _operationCurrentPersonId,
+                            "FR1",
                         new List<InvitedPersonForEditCommand> {
                             new InvitedPersonForEditCommand(_participantId1, null, "zoey@test.com", true, null),
                             new InvitedPersonForEditCommand(_participantId2, null, "zoey1@test.com", false, null)
@@ -1050,8 +1050,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                         null,
                         null,
                         new InvitedFunctionalRoleForEditCommand(
-                            null, 
-                            "FR1", 
+                            null,
+                            "FR1",
                             new List<InvitedPersonForEditCommand> {
                                 new InvitedPersonForEditCommand(400, null, "zoey@test.com", true, null),
                                 new InvitedPersonForEditCommand(500, null, "zoey1@test.com", false, null)
@@ -1327,7 +1327,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
-                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithoutParticipants, default);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsTrue(result);
             }
         }
@@ -1339,7 +1339,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
-                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithAnotherCreator, default);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithAnotherCreator, default);
                 Assert.IsFalse(result);
             }
         }
@@ -1347,13 +1347,17 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         [TestMethod]
         public async Task CurrentUserIsNotCreatorOfInvitationButContractor_ReturnsTrue()
         {
-            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(TestPlant, _currentUserOid.ToString(), "Contractor")).Returns(Task.FromResult(new ForeignApi.ProCoSysPerson()));
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                TestPlant,
+                _currentUserOid.ToString(),
+                "Contractor"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson()));
 
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
-                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithAnotherCreator, default);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithAnotherCreator, default);
                 Assert.IsTrue(result);
             }
         }
@@ -1367,7 +1371,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
-                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithAnotherCreator, default);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithAnotherCreator, default);
                 Assert.IsFalse(result);
             }
         }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -1351,7 +1351,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 TestPlant,
                 _currentUserOid.ToString(),
                 "Contractor"))
-                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson()));
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
 
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -281,7 +281,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                     TestPlant,
                     Organization.Contractor,
                     IpoParticipantType.Person,
-                    null,
+                    "Contractor",
                     "First1",
                     "Last",
                     "UN1",
@@ -372,8 +372,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
 
                         context2.SaveChangesAsync().Wait();
                         _invitationIdWithAnotherCreator = invitationWithAnotherCreator.Id;
+                        invitationWithAnotherCreator.AddParticipant(contractorParticipant2);
+                        context2.SaveChangesAsync().Wait();
                     }
                 }
+
 
                 _participantId1 = participant1.Id;
                 _participantId2 = participant2.Id;
@@ -392,7 +395,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeDp, _mcPkgScope, new List<string>());
                 Assert.IsTrue(result);
             }
@@ -403,7 +406,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeMdp, new List<string>(), _commPkgScope);
                 Assert.IsTrue(result);
             }
@@ -414,7 +417,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeMdp, _mcPkgScope, new List<string>());
                 Assert.IsFalse(result);
             }
@@ -425,7 +428,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeDp, new List<string>(), _commPkgScope);
                 Assert.IsFalse(result);
             }
@@ -436,7 +439,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeDp, _mcPkgScope, _commPkgScope);
                 Assert.IsFalse(result);
             }
@@ -447,7 +450,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeMdp, _mcPkgScope, _commPkgScope);
                 Assert.IsFalse(result);
             }
@@ -458,7 +461,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeDp,new List<string>(), new List<string>());
                 Assert.IsFalse(result);
             }
@@ -469,7 +472,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidScope(_typeMdp, new List<string>(), new List<string>());
                 Assert.IsFalse(result);
             }
@@ -480,7 +483,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.RequiredParticipantsMustBeInvited(_participantsOnlyRequired);
                 Assert.IsTrue(result);
             }
@@ -491,7 +494,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand>());
                 Assert.IsFalse(result);
             }
@@ -502,7 +505,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand> {
                     new ParticipantsForCommand(
                         Organization.Contractor,
@@ -526,7 +529,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand> { _participantsOnlyRequired[0] });
                 Assert.IsFalse(result);
             }
@@ -537,7 +540,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand> {
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -561,7 +564,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.RequiredParticipantsMustBeInvited(_participantsOnlyRequired);
                 Assert.IsTrue(result);
             }
@@ -572,7 +575,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidParticipantList(new List<ParticipantsForCommand> {
                     _participantsOnlyRequired[0],
                     _participantsOnlyRequired[1],
@@ -592,7 +595,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.IsValidParticipantList(new List<ParticipantsForCommand> {
                     _participantsOnlyRequired[0],
                     _participantsOnlyRequired[1],
@@ -612,7 +615,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var fr =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -645,7 +648,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
@@ -664,7 +667,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
@@ -683,7 +686,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
@@ -702,7 +705,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var fr = new ParticipantsForCommand(
                     Organization.Operation,
                     null,
@@ -725,7 +728,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var participantWithFunctionalRoleAndExternalEmail =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -745,7 +748,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var participantWithFunctionalRoleAndExternalEmail =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -765,7 +768,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var participantWithFunctionalRoleAndExternalEmail =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -785,7 +788,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -805,7 +808,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -825,7 +828,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.OnlyRequiredParticipantsHaveLowestSortKeys(_participantsOnlyRequired);
                 Assert.IsTrue(result);
             }
@@ -837,7 +840,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -856,7 +859,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = dut.OnlyRequiredParticipantsHaveLowestSortKeys(new List<ParticipantsForCommand> {
                     new ParticipantsForCommand(
                         Organization.Contractor,
@@ -881,7 +884,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -900,7 +903,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var externalPerson =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -919,7 +922,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -938,7 +941,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -957,7 +960,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -983,7 +986,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var externalPerson =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1002,7 +1005,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1021,7 +1024,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1040,7 +1043,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1067,7 +1070,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1079,7 +1082,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoExistsAsync(100, default);
                 Assert.IsFalse(result);
             }
@@ -1091,7 +1094,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1103,7 +1106,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1115,7 +1118,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1127,7 +1130,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoHasAccepterAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1139,7 +1142,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoHasAccepterAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1151,7 +1154,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1163,7 +1166,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1175,7 +1178,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1187,7 +1190,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoHasCompleterAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1199,7 +1202,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoHasCompleterAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1211,7 +1214,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
                 Assert.IsTrue(result);
             }
@@ -1223,7 +1226,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
                 Assert.IsTrue(result);
             }
@@ -1235,7 +1238,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
                 Assert.IsFalse(result);
             }
@@ -1247,7 +1250,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
                     await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _contractorId, default)
                 );
@@ -1261,7 +1264,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _commissioningId, default);
                 Assert.IsTrue(result);
             }
@@ -1273,7 +1276,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _additionalContractorId, default);
                 Assert.IsTrue(result);
             }
@@ -1285,7 +1288,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
                     await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _supplierId, default)
                 );
@@ -1299,7 +1302,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.SignerExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
                 Assert.IsTrue(result);
             }
@@ -1311,7 +1314,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.SignerExistsAsync(_invitationIdWithoutParticipants, _operationCurrentPersonId, default);
                 Assert.IsFalse(result);
             }
@@ -1323,8 +1326,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.CurrentUserIsCreatorOfInvitation(_invitationIdWithoutParticipants, default);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithoutParticipants, default);
                 Assert.IsTrue(result);
             }
         }
@@ -1335,8 +1338,36 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
-                var result = await dut.CurrentUserIsCreatorOfInvitation(_invitationIdWithAnotherCreator, default);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithAnotherCreator, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsNotCreatorOfInvitationButContractor_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(TestPlant, _currentUserOid.ToString(), "Contractor")).Returns(Task.FromResult(new ForeignApi.ProCoSysPerson()));
+
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithAnotherCreator, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsNotCreatorOfInvitationAndNotContractor_ReturnsFalse()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(TestPlant, _currentUserOid.ToString(), "Contractor")).Returns(Task.FromResult<ForeignApi.ProCoSysPerson>(null));
+
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation(_invitationIdWithAnotherCreator, default);
                 Assert.IsFalse(result);
             }
         }
@@ -1347,7 +1378,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithFrAsParticipants, IpoStatus.Planned, default);
                 Assert.IsTrue(result);
             }
@@ -1359,7 +1390,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithCurrentUserOidAsParticipants, IpoStatus.Accepted, default);
                 Assert.IsTrue(result);
             }
@@ -1371,7 +1402,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithCurrentUserOidAsParticipants, IpoStatus.Planned, default);
                 Assert.IsFalse(result);
             }
@@ -1383,7 +1414,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithCurrentUserOidAsParticipants, IpoStatus.Completed, default);
                 Assert.IsFalse(result);
             }
@@ -1395,7 +1426,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.SameUserUnAcceptingThatAcceptedAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1407,7 +1438,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
                 var result = await dut.SameUserUnAcceptingThatAcceptedAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 //This is not a full test coverage, because we do not have a history event for this accepting. We get false because there are not history events in this validation. Cannot add history event that is created by a user other than current user
                 Assert.IsFalse(result);

--- a/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
@@ -1179,36 +1179,6 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
         }
 
         [TestMethod]
-        public void CancelIpo_CallerIsNotCreator_ThrowsException()
-        {
-            TimeService.SetProvider(new ManualTimeProvider(new DateTime(2021, 1, 1, 12, 0, 0, DateTimeKind.Utc)));
-            var creator = new Person(new Guid("12345678-1234-1234-1234-123456789123"), "Test", "Person", "tp", "tp@pcs.pcs");
-            var caller = new Person(new Guid("99999999-9999-9999-9999-999999999999"), "Another", "Person", "ap", "ap@pcs.pcs");
-
-            // Set caller ID to a different ID than the creator
-            caller
-                .GetType()
-                .GetProperty(nameof(Person.Id))
-                ?.SetValue(caller, 1, null);
-
-            var dut = new Invitation(
-                TestPlant,
-                ProjectName,
-                Title,
-                Description,
-                DisciplineType.MDP,
-                new DateTime(2020, 8, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 8, 1, 13, 0, 0, DateTimeKind.Utc),
-                null,
-                null,
-                new List<CommPkg> {_commPkg1});
-
-            dut.SetCreated(creator);
-
-            Assert.ThrowsException<InvalidOperationException>(() => dut.CancelIpo(caller));
-        }
-
-        [TestMethod]
         public void CancelIpo_CallerIsNull_ThrowsException()
         {
             var dut = new Invitation(

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersons/GetPersonsQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersons/GetPersonsQueryHandlerTests.cs
@@ -15,8 +15,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersons
 {
     [TestClass]
     public class GetPersonsQueryHandlerTests : ReadOnlyTestsBase
-    {
-        
+    {        
         private IList<ProCoSysPerson> _mainApiPersons;
         private GetPersonsQuery _query;
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersons/GetPersonsQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersons/GetPersonsQueryHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersons
     [TestClass]
     public class GetPersonsQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IPersonApiService> _personApiServiceMock;
+        
         private IList<ProCoSysPerson> _mainApiPersons;
         private GetPersonsQuery _query;
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersonsWithPrivileges/GetPersonsWithPrivilegesQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetPersonsWithPrivileges/GetPersonsWithPrivilegesQueryHandlerTests.cs
@@ -17,7 +17,6 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetPersonsWithPrivileges
     [TestClass]
     public class GetPersonsWithPrivilegesQueryHandlerTests : ReadOnlyTestsBase
     {
-        private Mock<IPersonApiService> _personApiServiceMock;
         private IList<ProCoSysPerson> _mainApiContractorPersons;
         private IList<ProCoSysPerson> _mainApiConstructionPersons;
         private GetPersonsWithPrivilegesQuery _query;

--- a/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
@@ -4,6 +4,7 @@ using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.IPO.Domain.Events;
 using Equinor.ProCoSys.IPO.Domain.Time;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using Equinor.ProCoSys.IPO.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,6 +24,8 @@ namespace Equinor.ProCoSys.IPO.Test.Common
         protected Mock<IPlantProvider> _plantProviderMock;
         protected IPlantProvider _plantProvider;
         protected ICurrentUserProvider _currentUserProvider;
+        protected Mock<IPersonApiService> _personApiServiceMock;
+        protected IPersonApiService _personApiService;
         protected IEventDispatcher _eventDispatcher;
         protected ManualTimeProvider _timeProvider;
 
@@ -32,6 +35,9 @@ namespace Equinor.ProCoSys.IPO.Test.Common
             _plantProviderMock = new Mock<IPlantProvider>();
             _plantProviderMock.SetupGet(x => x.Plant).Returns(TestPlant);
             _plantProvider = _plantProviderMock.Object;
+            
+            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiService = _personApiServiceMock.Object;
 
             var currentUserProviderMock = new Mock<ICurrentUserProvider>();
             currentUserProviderMock.Setup(x => x.GetCurrentUserOid()).Returns(_currentUserOid);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -771,7 +771,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 .Setup(x => x.GetPersonInFunctionalRoleAsync(
                         TestFactory.PlantWithAccess,
                         _contractor.AsProCoSysPerson().AzureOid,
-                        "FRCA")).Returns(Task.FromResult(new ProCoSysPerson()));
+                        "FRCA"))
+                .Returns(Task.FromResult(_contractor.AsProCoSysPerson()));
 
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.CancelPunchOutAsync(

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -760,6 +760,36 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             AssertRowVersionChange(cancelPunchOutDto.RowVersion, newRowVersion);
         }
 
+        [TestMethod]
+        public async Task CancelPunchOut_AsContractor_ShouldCancelPunchOut()
+        {
+            // Arrange
+            var (invitationToCancelId, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participants);
+
+            TestFactory.Instance
+                .PersonApiServiceMock
+                .Setup(x => x.GetPersonInFunctionalRoleAsync(
+                        TestFactory.PlantWithAccess,
+                        _contractor.AsProCoSysPerson().AzureOid,
+                        "FRCA")).Returns(Task.FromResult(new ProCoSysPerson()));
+
+            // Act
+            var newRowVersion = await InvitationsControllerTestsHelper.CancelPunchOutAsync(
+                UserType.Contractor,
+                TestFactory.PlantWithAccess,
+                invitationToCancelId,
+                cancelPunchOutDto);
+
+            // Assert
+            var canceledInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
+                UserType.Contractor,
+                TestFactory.PlantWithAccess,
+                invitationToCancelId);
+
+            Assert.AreEqual(IpoStatus.Canceled, canceledInvitation.Status);
+            AssertRowVersionChange(cancelPunchOutDto.RowVersion, newRowVersion);
+        }
+
         private void AssertParticipants(InvitationDto invitation, List<CreateParticipantsDto> originalParticipants)
         {
             Assert.IsNotNull(invitation.Participants);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -36,6 +36,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         private ProCoSysMcPkg _mcPkgDetails2;
 
         protected TestProfile _sigurdSigner;
+        protected TestProfile _contractor;
         protected TestProfile _pernillaPlanner;
 
         [TestInitialize]
@@ -69,6 +70,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             
             _sigurdSigner = TestFactory.Instance.GetTestUserForUserType(UserType.Signer).Profile;
             _pernillaPlanner = TestFactory.Instance.GetTestUserForUserType(UserType.Planner).Profile;
+            _contractor = TestFactory.Instance.GetTestUserForUserType(UserType.Contractor).Profile;
 
             _participants = new List<CreateParticipantsDto>
             {
@@ -236,6 +238,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     "IPO",
                     It.IsAny<List<string>>()))
                 .Returns(Task.FromResult(_sigurdSigner.AsProCoSysPerson()));
+
+            TestFactory.Instance
+                .PersonApiServiceMock
+                .Setup(x => x.GetPersonByOidWithPrivilegesAsync(
+                    TestFactory.PlantWithAccess,
+                    _contractor.Oid,
+                    "IPO",
+                    It.IsAny<List<string>>()))
+                .Returns(Task.FromResult(_contractor.AsProCoSysPerson()));
 
             TestFactory.Instance
                 .PersonApiServiceMock

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -39,6 +39,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         private const string PlannerOid = "00000000-0000-0000-0000-000000000002";
         private const string ViewerOid = "00000000-0000-0000-0000-000000000003";
         private const string HackerOid = "00000000-0000-0000-0000-000000000666";
+        private const string ContractorOid = "00000000-0000-0000-0000-000000000007";
 
         private const string IntegrationTestEnvironment = "IntegrationTests";
         private readonly string _connectionString;
@@ -302,6 +303,8 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
             AddViewerUser(commonProCoSysPlants, commonProCoSysProjects);
     
             AddHackerUser(commonProCoSysProjects);
+
+            AddContractorUser(commonProCoSysPlants, commonProCoSysProjects);
             
             var webHostBuilder = WithWebHostBuilder(builder =>
             {
@@ -430,6 +433,36 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                         Permissions.IPO_DELETE,
                         Permissions.IPO_ATTACHFILE,
                         Permissions.IPO_DETACHFILE,
+                        Permissions.IPO_VOIDUNVOID,
+                    },
+                    ProCoSysProjects = commonProCoSysProjects
+                });
+
+        private void AddContractorUser(
+            List<ProCoSysPlant> commonProCoSysPlants,
+            List<ProCoSysProject> commonProCoSysProjects)
+            => _testUsers.Add(UserType.Contractor,
+                new TestUser
+                {
+                    Profile =
+                        new TestProfile
+                        {
+                            FirstName = "Conte",
+                            LastName = "Contractor",
+                            UserName = "ContractorUserName",
+                            Oid = ContractorOid,
+                            Email = "conte.contractor@pcs.pcs"  
+                        },
+                    ProCoSysPlants = commonProCoSysPlants,
+                    ProCoSysPermissions = new List<string>
+                    {
+                        Permissions.COMMPKG_READ,
+                        Permissions.MCPKG_READ,
+                        Permissions.PROJECT_READ,
+                        Permissions.LIBRARY_FUNCTIONAL_ROLE_READ,
+                        Permissions.USER_READ,
+                        Permissions.IPO_READ,
+                        Permissions.IPO_WRITE,
                         Permissions.IPO_VOIDUNVOID,
                     },
                     ProCoSysProjects = commonProCoSysProjects

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
@@ -6,6 +6,7 @@
         Signer,
         Planner,
         Viewer,
-        Hacker
+        Hacker,
+        Contractor
     }
 }


### PR DESCRIPTION
Both creators and all members of functional role, when the functional role is used on Contractor should be able to cancel IPO
Changed logic and modified/added tests.

[AB#87190](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/87190)
