### PR TITLE
bug/89292-IPO missing participants

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
@@ -94,18 +94,15 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Repositories
 
         public void UpdateFunctionalRoleCodesOnInvitations(string plant, string functionalRoleCodeOld, string functionalRoleCodeNew)
         {
-            if (functionalRoleCodeOld != null)
-            {
-                var invitationsToUpdate = _context.Invitations
-                    .Include(i => i.Participants)
-                    .Where(invitation => invitation.Participants
-                    .Any(p => p.FunctionalRoleCode == functionalRoleCodeOld) && invitation.Plant == plant);
+            var invitationsToUpdate = _context.Invitations
+                .Include(i => i.Participants)
+                .Where(invitation => invitation.Participants
+                .Any(p => p.FunctionalRoleCode == functionalRoleCodeOld) && invitation.Plant == plant);
 
-                foreach (var invitation in invitationsToUpdate)
-                {
-                    invitation.Participants.Where(p => p.FunctionalRoleCode == functionalRoleCodeOld).ToList()
-                        .ForEach(p => p.FunctionalRoleCode = functionalRoleCodeNew);
-                }
+            foreach (var invitation in invitationsToUpdate)
+            {
+                invitation.Participants.Where(p => p.FunctionalRoleCode == functionalRoleCodeOld).ToList()
+                    .ForEach(p => p.FunctionalRoleCode = functionalRoleCodeNew);
             }
         }
 

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
@@ -94,15 +94,18 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Repositories
 
         public void UpdateFunctionalRoleCodesOnInvitations(string plant, string functionalRoleCodeOld, string functionalRoleCodeNew)
         {
-            var invitationsToUpdate = _context.Invitations
-                .Include(i => i.Participants)
-                .Where(invitation => invitation.Participants
-                .Any(p => p.FunctionalRoleCode == functionalRoleCodeOld) && invitation.Plant == plant);
-
-            foreach (var invitation in invitationsToUpdate)
+            if (functionalRoleCodeOld != null)
             {
-                invitation.Participants.Where(p => p.FunctionalRoleCode == functionalRoleCodeOld).ToList()
-                    .ForEach(p => p.FunctionalRoleCode = functionalRoleCodeNew);
+                var invitationsToUpdate = _context.Invitations
+                    .Include(i => i.Participants)
+                    .Where(invitation => invitation.Participants
+                    .Any(p => p.FunctionalRoleCode == functionalRoleCodeOld) && invitation.Plant == plant);
+
+                foreach (var invitation in invitationsToUpdate)
+                {
+                    invitation.Participants.Where(p => p.FunctionalRoleCode == functionalRoleCodeOld).ToList()
+                        .ForEach(p => p.FunctionalRoleCode = functionalRoleCodeNew);
+                }
             }
         }
 

--- a/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/BusReceiverService.cs
@@ -250,7 +250,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
                 });
             _plantSetter.SetPlant(libraryEvent.Plant);
 
-            if (libraryEvent.Type == FunctionalRoleLibraryType)
+            if (libraryEvent.Type == FunctionalRoleLibraryType && libraryEvent.CodeOld != null)
             {
                 _invitationRepository.UpdateFunctionalRoleCodesOnInvitations(libraryEvent.Plant, libraryEvent.CodeOld, libraryEvent.Code);
             }


### PR DESCRIPTION
Added a check for oldCode=null, to prevent all rows in Participants table with FunctionalRoleCode=null to be set when a functional role is created in the same plant.

[AB#89292](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89292)