### PR TITLE
Only creator and users with FR = Contractor should be able to cancel …

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -78,16 +78,19 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 _logger.LogError(e, $"Fusion meeting error. MeetingId={invitation.MeetingId}.");
             }
 
-            var invitationDto = ConvertToInvitationDto(invitation, meeting);
+            var invitationDto = ConvertToInvitationDto(invitation, meeting, createdBy);
 
             return new SuccessResult<InvitationDto>(invitationDto);
         }
 
-        private InvitationDto ConvertToInvitationDto(Invitation invitation,  GeneralMeeting meeting)
+        private InvitationDto ConvertToInvitationDto(Invitation invitation,  GeneralMeeting meeting, Person createdBy)
         {
             var canEdit = meeting != null && 
                            (meeting.Participants.Any(p => p.Person.Id == _currentUserProvider.GetCurrentUserOid()) || 
                            meeting.Organizer.Id == _currentUserProvider.GetCurrentUserOid());
+
+
+            var canCancel = (createdBy.Id == invitation.CreatedById);
 
             var invitationResult = new InvitationDto(
                 invitation.ProjectName,
@@ -100,7 +103,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 invitation.StartTimeUtc,
                 invitation.EndTimeUtc,
                 canEdit,
-                invitation.RowVersion.ConvertToString())
+                invitation.RowVersion.ConvertToString(), 
+                canCancel)
             {
                 Participants = ConvertToParticipantDto(invitation.Participants),
                 McPkgScope = ConvertToMcPkgDto(invitation.McPkgs),

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/InvitationDto.cs
@@ -17,7 +17,8 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             DateTime startTimeUtc,
             DateTime endTimeUtc,
             bool canEdit,
-            string rowVersion)
+            string rowVersion,
+            bool canCancel)
         {
             ProjectName = projectName;
             Title = title;
@@ -29,6 +30,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             StartTimeUtc = startTimeUtc;
             EndTimeUtc = endTimeUtc;
             CanEdit = canEdit;
+            CanCancel = canCancel;
             RowVersion = rowVersion;
         }
 
@@ -42,6 +44,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public DateTime StartTimeUtc { get; }
         public DateTime EndTimeUtc { get; }
         public bool CanEdit { get; }
+        public bool CanCancel { get; }
         public string RowVersion { get; }
         public IEnumerable<ParticipantDto> Participants { get; set; }
         public IEnumerable<McPkgScopeDto> McPkgScope { get; set; }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -1118,6 +1118,22 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         }
 
         [TestMethod]
+        public async Task CancelPunchOut_AsPlanner_ShouldReturnBadRequest()
+        {
+            // Arrange
+            var (invitationToCancelId, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participantsForSigning, UserType.Creator);
+
+            // Act
+            await InvitationsControllerTestsHelper.CancelPunchOutAsync(
+                           UserType.Planner,
+                           TestFactory.PlantWithAccess,
+                           invitationToCancelId,
+                           cancelPunchOutDto,
+                           HttpStatusCode.BadRequest,
+                           "Current user is not the creator of the invitation and not in Contractor Functional Role!");
+        }
+
+        [TestMethod]
         public async Task CancelPunchOut_AsPlanner_ShouldReturnConflict_WhenWrongInvitationRowVersion()
         {
             // Arrange

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTests.cs
@@ -96,7 +96,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             var commPkgs = await InvitationsControllerTestsHelper.GetLatestMdpIpoOnCommPkgsAsync(
                 UserType.Viewer,
                 TestFactory.PlantWithAccess,
-                new List<string>{KnownTestData.CommPkgNo},
+                new List<string> { KnownTestData.CommPkgNo },
                 TestFactory.ProjectWithAccess);
 
             // Assert
@@ -291,7 +291,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             //Arrange
             var (invitationToChangeId, participantToChangeDtos) = await CreateValidParticipantToChangeDtosAsync(_participantsForSigning);
             var updatedNote = participantToChangeDtos[0].Note;
-            
+
             //Act
             await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
                 UserType.Signer,
@@ -448,7 +448,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 });
             var (invitationId, editInvitationDto) = await CreateValidEditInvitationDtoAsync(participants);
             Assert.AreEqual(3, editInvitationDto.UpdatedParticipants.Count());
-            
+
             var editParticipants = editInvitationDto.UpdatedParticipants.ElementAt(2);
             Assert.AreEqual(email1, editParticipants.ExternalEmail.Email);
             editParticipants.ExternalEmail.Email = email2;
@@ -736,23 +736,23 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             Assert.IsNotNull(historyEvent.Description);
             Assert.IsNotNull(historyEvent.EventType);
         }
-        
+
         [TestMethod]
-        public async Task CancelPunchOut_AsPlanner_ShouldCancelPunchOut()
+        public async Task CancelPunchOut_AsCreator_ShouldCancelPunchOut()
         {
             // Arrange
-            var (invitationToCancelId, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participantsForSigning);
+            var (invitationToCancelId, cancelPunchOutDto) = await CreateValidCancelPunchOutDtoAsync(_participantsForSigning, UserType.Creator);
 
             // Act
             var newRowVersion = await InvitationsControllerTestsHelper.CancelPunchOutAsync(
-                UserType.Planner,
+                UserType.Creator,
                 TestFactory.PlantWithAccess,
                 invitationToCancelId,
                 cancelPunchOutDto);
 
             // Assert
             var canceledInvitation = await InvitationsControllerTestsHelper.GetInvitationAsync(
-                UserType.Planner,
+                UserType.Creator,
                 TestFactory.PlantWithAccess,
                 invitationToCancelId);
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -507,10 +507,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             return attachmentDtos.Single(t => t.FileName == fileToBeUploaded.FileName);
         }
 
-        internal async Task<(int, CancelPunchOutDto)> CreateValidCancelPunchOutDtoAsync(List<CreateParticipantsDto> participants)
+        internal async Task<(int, CancelPunchOutDto)> CreateValidCancelPunchOutDtoAsync(List<CreateParticipantsDto> participants, UserType userType = UserType.Planner)
         {
             var id = await InvitationsControllerTestsHelper.CreateInvitationAsync(
-                UserType.Planner,
+                userType,
                 TestFactory.PlantWithAccess,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString(),

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -38,6 +38,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         private const string SignerOid = "00000000-0000-0000-0000-000000000001";
         private const string PlannerOid = "00000000-0000-0000-0000-000000000002";
         private const string ViewerOid = "00000000-0000-0000-0000-000000000003";
+        private const string CreatorOid = "00000000-0000-0000-0000-000000000004";
         private const string HackerOid = "00000000-0000-0000-0000-000000000666";
         private const string ContractorOid = "00000000-0000-0000-0000-000000000007";
 
@@ -305,7 +306,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
             AddHackerUser(commonProCoSysProjects);
 
             AddContractorUser(commonProCoSysPlants, commonProCoSysProjects);
-            
+
+            AddCreatorUser(commonProCoSysPlants, commonProCoSysProjects); 
+
             var webHostBuilder = WithWebHostBuilder(builder =>
             {
                 builder.UseEnvironment(IntegrationTestEnvironment);
@@ -464,6 +467,40 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                         Permissions.IPO_READ,
                         Permissions.IPO_WRITE,
                         Permissions.IPO_VOIDUNVOID,
+                    },
+                    ProCoSysProjects = commonProCoSysProjects
+                });
+
+        private void AddCreatorUser(
+            List<ProCoSysPlant> commonProCoSysPlants,
+            List<ProCoSysProject> commonProCoSysProjects)
+            => _testUsers.Add(UserType.Creator,
+                new TestUser
+                {
+                    Profile =
+                        new TestProfile
+                        {
+                            FirstName = "Bill",
+                            LastName = "Shankly",
+                            UserName = "ShanklyCreator",
+                            Oid = CreatorOid,
+                            Email = "bill.shankly@pcs.pcs"
+                        },
+                    ProCoSysPlants = commonProCoSysPlants,
+                    ProCoSysPermissions = new List<string>
+                    {
+                        Permissions.COMMPKG_READ,
+                        Permissions.MCPKG_READ,
+                        Permissions.PROJECT_READ,
+                        Permissions.LIBRARY_FUNCTIONAL_ROLE_READ,
+                        Permissions.USER_READ,
+                        Permissions.IPO_READ,
+                        Permissions.IPO_WRITE,
+                        Permissions.IPO_CREATE,
+                        Permissions.IPO_DELETE,
+                        Permissions.IPO_ATTACHFILE,
+                        Permissions.IPO_DETACHFILE,
+                        Permissions.IPO_VOIDUNVOID
                     },
                     ProCoSysProjects = commonProCoSysProjects
                 });

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
@@ -7,6 +7,7 @@
         Planner,
         Viewer,
         Hacker,
-        Contractor
+        Contractor,
+        Creator
     }
 }


### PR DESCRIPTION
Added attribute CanCancel to IPO. For now, it's set when the user is the creator of the IPO. 
Also implemented that only the IPO-creator and users with Functional Role = Contractor can cancel IPOs.

[AB#81008](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81008)