### PR TITLE
Feature/89474 add endpoints to edit note and attended status on participants

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/EventHandlers/HistoryEvents/AttendedStatusUpdatedEventHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/EventHandlers/HistoryEvents/AttendedStatusUpdatedEventHandler.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.HistoryAggregate;
+using Equinor.ProCoSys.IPO.Domain.Events.PreSave;
+using MediatR;
+
+namespace Equinor.ProCoSys.IPO.Command.EventHandlers.HistoryEvents
+{
+    public class AttendedStatusUpdatedEventHandler : INotificationHandler<AttendedStatusUpdatedEvent>
+    {
+        private readonly IHistoryRepository _historyRepository;
+
+        public AttendedStatusUpdatedEventHandler(IHistoryRepository historyRepository) 
+            => _historyRepository = historyRepository;
+
+        public Task Handle(AttendedStatusUpdatedEvent notification, CancellationToken cancellationToken)
+        {
+            const EventType eventType = EventType.AttendedStatusUpdated;
+            var history = new History(notification.Plant, eventType.GetDescription(), notification.ObjectGuid, eventType);
+            _historyRepository.Add(history);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/EventHandlers/HistoryEvents/NoteUpdatedEventHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/EventHandlers/HistoryEvents/NoteUpdatedEventHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.HistoryAggregate;
+using Equinor.ProCoSys.IPO.Domain.Events.PreSave;
+using MediatR;
+
+namespace Equinor.ProCoSys.IPO.Command.EventHandlers.HistoryEvents
+{
+    public class NoteUpdatedEventHandler : INotificationHandler<NoteUpdatedEvent>
+    {
+        private readonly IHistoryRepository _historyRepository;
+
+        public NoteUpdatedEventHandler(IHistoryRepository historyRepository) 
+            => _historyRepository = historyRepository;
+
+        public Task Handle(NoteUpdatedEvent notification, CancellationToken cancellationToken)
+        {
+            const EventType eventType = EventType.NoteUpdated;
+            var description = $"{eventType.GetDescription()} - '{notification.Note}'";
+            var history = new History(notification.Plant, description, notification.ObjectGuid, eventType);
+            _historyRepository.Add(history);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandler.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using MediatR;
 using ServiceResult;
 
@@ -14,26 +13,20 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
 {
     public class AcceptPunchOutCommandHandler : IRequestHandler<AcceptPunchOutCommand, Result<string>>
     {
-        private readonly IPlantProvider _plantProvider;
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
         private readonly IPersonRepository _personRepository;
 
         public AcceptPunchOutCommandHandler(
-            IPlantProvider plantProvider,
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
-            ICurrentUserProvider currentUserProvider, 
-            IPersonApiService personApiService,
+            ICurrentUserProvider currentUserProvider,
             IPersonRepository personRepository)
         {
-            _plantProvider = plantProvider;
             _invitationRepository = invitationRepository;
             _unitOfWork = unitOfWork;
             _currentUserProvider = currentUserProvider;
-            _personApiService = personApiService;
             _personRepository = personRepository;
         }
 
@@ -53,8 +46,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
                     .SingleOrDefault(p => p.SortKey == 1 &&
                                           p.FunctionalRoleCode != null &&
                                           p.Type == IpoParticipantType.FunctionalRole);
-
-                await AcceptIpoAsPersonInFunctionalRoleAsync(invitation, functionalRole, currentUser, acceptedAtUtc, request.ParticipantRowVersion);
+                invitation.AcceptIpo(functionalRole, request.ParticipantRowVersion, currentUser, acceptedAtUtc);
             }
             else
             {
@@ -67,7 +59,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             return new SuccessResult<string>(invitation.RowVersion.ConvertToString());
         }
-
         
 
         private void UpdateNotesOnParticipants(Invitation invitation, IList<UpdateNoteOnParticipantForCommand> participants)
@@ -77,28 +68,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
                 var ipoParticipant = invitation.Participants.Single(p => p.Id == participant.Id);
                 ipoParticipant.Note = participant.Note;
                 ipoParticipant.SetRowVersion(participant.RowVersion);
-            }
-        }
-
-        private async Task AcceptIpoAsPersonInFunctionalRoleAsync(
-            Invitation invitation,
-            Participant participant,
-            Person currentUser,
-            DateTime acceptedAtUtc,
-            string participantRowVersion)
-        {
-            var person = await _personApiService.GetPersonInFunctionalRoleAsync(
-                _plantProvider.Plant,
-                _currentUserProvider.GetCurrentUserOid().ToString(),
-                participant.FunctionalRoleCode);
-
-            if (person != null)
-            {
-                invitation.AcceptIpo(participant, participantRowVersion, currentUser, acceptedAtUtc);
-            }
-            else
-            {
-                throw new IpoValidationException($"Person was not found in functional role with code '{participant.FunctionalRoleCode}'");
             }
         }
     }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
                 => await invitationValidator.IpoHasAccepterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeTheAssignedPersonIfPersonParticipant(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidAccepterParticipantExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.CurrentUserIsValidAccepterParticipantAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
                 => await invitationValidator.IpoHasCompleterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeTheAssignedPersonIfPersonParticipant(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidCompleterParticipantExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.CurrentUserIsValidCompleterParticipantAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/InvitationHelper.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/InvitationHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.IPO.ForeignApi;
@@ -15,6 +17,15 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
 
         public static bool ParticipantIsSigningParticipant(ParticipantsForCommand participant) 
             => participant.Organization != Organization.External && participant.Organization != Organization.Supplier;
+
+        public static async Task<bool> HasIpoAdminPrivilege(
+            IPermissionCache permissionCache,
+            IPlantProvider plantProvider,
+            ICurrentUserProvider currentUserProvider)
+        {
+            var permissions = await permissionCache.GetPermissionsForUserAsync(plantProvider.Plant, currentUserProvider.GetCurrentUserOid());
+            return permissions != null && permissions.Contains("IPO/ADMIN");
+        }
 
         public static List<BuilderParticipant> SplitAndCreateOutlookParticipantsFromEmailList(
             string emails)

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommand.cs
@@ -1,4 +1,4 @@
-﻿                                                                                                                                                                                                                         using MediatR;
+﻿using MediatR;
 using ServiceResult;
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommand.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+﻿                                                                                                                                                                                                                         using MediatR;
 using ServiceResult;
 
 namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandHandler.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using MediatR;
 using ServiceResult;
 
@@ -12,26 +11,20 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
 {
     public class SignPunchOutCommandHandler : IRequestHandler<SignPunchOutCommand, Result<string>>
     {
-        private readonly IPlantProvider _plantProvider;
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
         private readonly IPersonRepository _personRepository;
 
         public SignPunchOutCommandHandler(
-            IPlantProvider plantProvider,
             IInvitationRepository invitationRepository,
             IUnitOfWork unitOfWork,
             ICurrentUserProvider currentUserProvider, 
-            IPersonApiService personApiService,
             IPersonRepository personRepository)
         {
-            _plantProvider = plantProvider;
             _invitationRepository = invitationRepository;
             _unitOfWork = unitOfWork;
             _currentUserProvider = currentUserProvider;
-            _personApiService = personApiService;
             _personRepository = personRepository;
         }
 
@@ -40,39 +33,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
             var invitation = await _invitationRepository.GetByIdAsync(request.InvitationId);
             var currentUser = await _personRepository.GetByOidAsync(_currentUserProvider.GetCurrentUserOid());
             var participant = invitation.Participants.Single(p => p.Id == request.ParticipantId);
-
-            if (participant.FunctionalRoleCode != null)
-            {
-                await SignIpoAsPersonInFunctionalRoleAsync(invitation, participant, currentUser, request.ParticipantRowVersion);
-            }
-            else
-            {
-                invitation.SignIpo(participant, currentUser, request.ParticipantRowVersion);
-            }
+            invitation.SignIpo(participant, currentUser, request.ParticipantRowVersion);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             return new SuccessResult<string>(participant.RowVersion.ConvertToString());
-        }
-
-        private async Task SignIpoAsPersonInFunctionalRoleAsync(
-            Invitation invitation,
-            Participant participant,
-            Person currentUser,
-            string participantRowVersion)
-        {
-            var person = await _personApiService.GetPersonInFunctionalRoleAsync(
-                _plantProvider.Plant,
-                _currentUserProvider.GetCurrentUserOid().ToString(),
-                participant.FunctionalRoleCode);
-
-            if (person != null)
-            {
-                invitation.SignIpo(participant, currentUser, participantRowVersion);
-            }
-            else
-            {
-                throw new IpoValidationException($"Person was not found in functional role with code '{participant.FunctionalRoleCode}'");
-            }
         }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
@@ -46,7 +46,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
                 => await invitationValidator.SignerExistsAsync(invitationId, participantId, cancellationToken);
 
             async Task<bool> BeTheAssignedPersonIfPersonParticipant(int invitationId, int participantId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidSigningParticipantExistsAsync(invitationId, participantId, cancellationToken);
+                => await invitationValidator.CurrentUserIsValidSigningParticipantAsync(invitationId, participantId, cancellationToken);
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
@@ -29,9 +29,12 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
                 .MustAsync((command, cancellationToken) => BeASigningParticipantOnIpo(command.InvitationId, command.ParticipantId, cancellationToken))
                 .WithMessage(command =>
                     $"Participant is not assigned to sign this IPO! ParticipantId={command.ParticipantId}")
-                .MustAsync((command, cancellationToken) => BeTheAssignedPersonIfPersonParticipant(command.InvitationId,command.ParticipantId, cancellationToken))
+                .MustAsync((command, cancellationToken) => BeTheAssignedPersonIfPersonParticipant(command.InvitationId, command.ParticipantId, cancellationToken))
                 .WithMessage(command =>
-                    "Person signing is not assigned to sign IPO, or there is not a valid functional role on the IPO!");
+                    "Person signing is not assigned to sign IPO, or there is not a valid functional role on the IPO!")
+                .MustAsync((command, cancellationToken) => BeUnsignedParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    "Participant is already signed!");
 
             async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);
@@ -47,6 +50,9 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
+            
+            async Task<bool> BeUnsignedParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
+                => !await invitationValidator.IsSignedParticipantAsync(participantId, invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/SignPunchOut/SignPunchOutCommandValidator.cs
@@ -52,7 +52,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
             
             async Task<bool> BeUnsignedParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
-                => !await invitationValidator.IsSignedParticipantAsync(participantId, invitationId, cancellationToken);
+                => !await invitationValidator.ParticipantIsSignedAsync(participantId, invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidator.cs
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut
                 => await invitationValidator.IpoHasAccepterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAdminOrThePersonWhoAccepted(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.AdminOrSameUserThatAcceptedIsUnAcceptingAsync(invitationId, cancellationToken);
+                => await invitationValidator.CurrentUserIsAdminOrValidAccepterParticipantAsync(invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidator.cs
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
                 => await invitationValidator.IpoHasCompleterAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAdminOrThePersonWhoCompleted(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.AdminOrSameUserThatCompletedIsUnCompletingAsync(invitationId, cancellationToken);
+                => await invitationValidator.CurrentUserIsAdminOrValidCompletorParticipantAsync(invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandHandler.cs
@@ -3,8 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
-using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using MediatR;
 using ServiceResult;
 
@@ -12,65 +10,25 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
 {
     public class UnSignPunchOutCommandHandler : IRequestHandler<UnSignPunchOutCommand, Result<string>>
     {
-        private readonly IPlantProvider _plantProvider;
         private readonly IInvitationRepository _invitationRepository;
         private readonly IUnitOfWork _unitOfWork;
-        private readonly ICurrentUserProvider _currentUserProvider;
-        private readonly IPersonApiService _personApiService;
-        private readonly IPersonRepository _personRepository;
 
         public UnSignPunchOutCommandHandler(
-            IPlantProvider plantProvider,
             IInvitationRepository invitationRepository,
-            IUnitOfWork unitOfWork,
-            ICurrentUserProvider currentUserProvider,
-            IPersonApiService personApiService,
-            IPersonRepository personRepository)
+            IUnitOfWork unitOfWork)
         {
-            _plantProvider = plantProvider;
             _invitationRepository = invitationRepository;
             _unitOfWork = unitOfWork;
-            _currentUserProvider = currentUserProvider;
-            _personApiService = personApiService;
-            _personRepository = personRepository;
         }
 
         public async Task<Result<string>> Handle(UnSignPunchOutCommand request, CancellationToken cancellationToken)
         {
             var invitation = await _invitationRepository.GetByIdAsync(request.InvitationId);
-            var currentUserAzureOid = _currentUserProvider.GetCurrentUserOid().ToString();
-            var participant = invitation.Participants.SingleOrDefault(p => p.Id == request.ParticipantId);
-
-            if (participant.FunctionalRoleCode != null)
-            {
-                await UnSignIpoAsPersonInFunctionalRoleAsync(invitation, participant, request.ParticipantRowVersion);
-            }
-            else
-            {
-                invitation.UnSignIpo(participant, request.ParticipantRowVersion);
-            }
+            var participant = invitation.Participants.Single(p => p.Id == request.ParticipantId);
+            invitation.UnSignIpo(participant, request.ParticipantRowVersion);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             return new SuccessResult<string>(participant.RowVersion.ConvertToString());
-        }
-        private async Task UnSignIpoAsPersonInFunctionalRoleAsync(
-            Invitation invitation,
-            Participant participant,
-            string participantRowVersion)
-        {
-            var person = await _personApiService.GetPersonInFunctionalRoleAsync(
-                _plantProvider.Plant,
-                _currentUserProvider.GetCurrentUserOid().ToString(),
-                participant.FunctionalRoleCode);
-
-            if (person != null)
-            {
-                invitation.UnSignIpo(participant, participantRowVersion);
-            }
-            else
-            {
-                throw new IpoValidationException($"Person was not found in functional role with code '{participant.FunctionalRoleCode}'");
-            }
         }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandValidator.cs
@@ -13,8 +13,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
         {
             CascadeMode = CascadeMode.Stop;
 
-            // Todo Validators for unsign, sign, accept, unaccept, complete and uncomplete should all have a new rule checking if participant has signed or not
-            // nothing prevent to sign or unsign twice in a row for same participant as it is now
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
@@ -24,7 +22,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
                     $"Participant with ID does not exist on invitation! Id={command.ParticipantId}")
                 .MustAsync((command, cancellationToken) => BeANonCanceledInvitation(command.InvitationId, cancellationToken))
                 .WithMessage(command =>
-                    "Invitation is canceled, and thus cannot be signed!")
+                    "Invitation is canceled, and thus cannot be unsigned!")
                 .Must(command => HaveAValidRowVersion(command.ParticipantRowVersion))
                 .WithMessage(command =>
                     $"Participant row version is not valid! ParticipantRowVersion={command.ParticipantRowVersion}")
@@ -33,7 +31,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
                     $"Participant is not assigned to unsign this IPO! ParticipantId={command.ParticipantId}")
                 .MustAsync((command, cancellationToken) => BeTheAssignedPersonIfPersonParticipant(command.InvitationId, command.ParticipantId, cancellationToken))
                 .WithMessage(command =>
-                    "Person unsigning is not assigned to unsign IPO, or there is not a valid functional role on the IPO!");
+                    "Person unsigning is not assigned to unsign IPO, or there is not a valid functional role on the IPO!")
+                .MustAsync((command, cancellationToken) => BeSignedParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    "An unsigned participant cannot be unsigned!");
 
             async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);
@@ -49,6 +50,9 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
+
+            async Task<bool> BeSignedParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IsSignedParticipantAsync(participantId, invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandValidator.cs
@@ -52,7 +52,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
 
             async Task<bool> BeSignedParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.IsSignedParticipantAsync(participantId, invitationId, cancellationToken);
+                => await invitationValidator.ParticipantIsSignedAsync(participantId, invitationId, cancellationToken);
 
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandValidator.cs
@@ -46,7 +46,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut
                 => await invitationValidator.SignerExistsAsync(invitationId, participantId, cancellationToken);
 
             async Task<bool> BeAdminOrTheAssignedPersonIfPersonParticipant(int invitationId, int participantId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidUnsigningParticipantExistsAsync(invitationId, participantId, cancellationToken);
+                => await invitationValidator.CurrentUserIsAdminOrValidUnsigningParticipantAsync(invitationId, participantId, cancellationToken);
 
             async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
@@ -45,7 +45,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusAn
                 => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
 
             async Task<bool> BeTheAssignedContractorIfPersonParticipant(int invitationId, CancellationToken cancellationToken)
-                => await invitationValidator.ValidCompleterParticipantExistsAsync(invitationId, cancellationToken);
+                => await invitationValidator.CurrentUserIsValidCompleterParticipantAsync(invitationId, cancellationToken);
 
             async Task<bool> BeAContractorOnIpo(int invitationId, CancellationToken cancellationToken)
                 => await invitationValidator.IpoHasCompleterAsync(invitationId, cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommand.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant
+{
+    public class UpdateAttendedStatusOnParticipantCommand : IRequest<Result<string>>, IInvitationCommandRequest
+    {
+        public UpdateAttendedStatusOnParticipantCommand(
+            int invitationId,
+            int participantId,
+            bool attended, 
+            string rowVersion
+        )
+        {
+            InvitationId = invitationId;
+            ParticipantId = participantId;
+            Attended = attended;
+            RowVersion = rowVersion;
+        }
+
+        public int InvitationId { get; }
+        public int ParticipantId { get; }
+        public bool Attended { get; }
+        public string RowVersion { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandHandler.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant
+{
+    public class UpdateAttendedStatusOnParticipantCommandHandler : IRequestHandler<UpdateAttendedStatusOnParticipantCommand, Result<string>>
+    {
+        private readonly IInvitationRepository _invitationRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public UpdateAttendedStatusOnParticipantCommandHandler(
+            IInvitationRepository invitationRepository,
+            IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+            _invitationRepository = invitationRepository;
+        }
+
+        public async Task<Result<string>> Handle(UpdateAttendedStatusOnParticipantCommand request, CancellationToken cancellationToken)
+        {
+            var invitation = await _invitationRepository.GetByIdAsync(request.InvitationId);
+            var participant = invitation.Participants.Single(p => p.Id == request.ParticipantId);
+            invitation.UpdateAttendedStatus(participant, request.Attended, request.RowVersion);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return new SuccessResult<string>(participant.RowVersion.ConvertToString());
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandValidator.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators;
+using Equinor.ProCoSys.IPO.Command.Validators.RowVersionValidators;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using FluentValidation;
+
+namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant
+{
+    public class UpdateAttendedStatusOnParticipantCommandValidator : AbstractValidator<UpdateAttendedStatusOnParticipantCommand>
+    {
+        public UpdateAttendedStatusOnParticipantCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
+        {
+            CascadeMode = CascadeMode.Stop;
+
+            RuleFor(command => command)
+                .MustAsync((command, cancellationToken) =>
+                    BeAnExistingInvitation(command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
+                .MustAsync((command, cancellationToken) =>
+                    NotBeCancelledInvitation(command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    $"Cannot perform updates on cancelled invitation! Id={command.InvitationId}")
+                .MustAsync((command, cancellationToken) =>
+                    BeAnExistingParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    $"Participant with ID does not exist on invitation! ParticipantId={command.ParticipantId}")
+                .Must(command => HaveAValidRowVersion(command.RowVersion))
+                .WithMessage(command =>
+                    $"Participant doesn't have valid rowVersion! ParticipantRowVersion={command.RowVersion}")
+                .MustAsync((command, cancellationToken) =>
+                    HavePermissionToEdit(command.ParticipantId, command.InvitationId, cancellationToken))
+                .WithMessage("The current user does not have sufficient privileges to edit this participant.")
+                .MustAsync((command, cancellationToken) =>
+                    HaveOppositeAttendedStatus(command.ParticipantId, command.InvitationId, command.Attended, cancellationToken))
+                .WithMessage("Cannot update participant to its current attendedStatus.");
+
+            async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);
+            
+            async Task<bool> NotBeCancelledInvitation(int invitationId, CancellationToken cancellationToken)
+                => !await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Canceled, cancellationToken);
+
+            async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
+            
+            async Task<bool> HavePermissionToEdit(int participantId, int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.HasPermissionToEditParticipantAsync(participantId, invitationId, cancellationToken);
+
+            async Task<bool> HaveOppositeAttendedStatus(int participantId, int invitationId, bool attended, CancellationToken cancellationToken)
+                => await invitationValidator.HasOppositeAttendedStatusAsync(participantId, invitationId, attended, cancellationToken);
+
+            bool HaveAValidRowVersion(string rowVersion)
+                => rowVersionValidator.IsValid(rowVersion);
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommand.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommand.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant
+{
+    public class UpdateNoteOnParticipantCommand : IRequest<Result<string>>, IInvitationCommandRequest
+    {
+        public UpdateNoteOnParticipantCommand(
+            int invitationId,
+            int participantId,
+            string note, 
+            string rowVersion
+        )
+        {
+            InvitationId = invitationId;
+            ParticipantId = participantId;
+            Note = note;
+            RowVersion = rowVersion;
+        }
+
+        public int InvitationId { get; }
+        public int ParticipantId { get; }
+        public string Note { get; }
+        public string RowVersion { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandHandler.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant
+{
+    public class UpdateNoteOnParticipantCommandHandler : IRequestHandler<UpdateNoteOnParticipantCommand, Result<string>>
+    {
+        private readonly IInvitationRepository _invitationRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public UpdateNoteOnParticipantCommandHandler(
+            IInvitationRepository invitationRepository,
+            IUnitOfWork unitOfWork)
+        {
+            _invitationRepository = invitationRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<Result<string>> Handle(UpdateNoteOnParticipantCommand request, CancellationToken cancellationToken)
+        {
+            var invitation = await _invitationRepository.GetByIdAsync(request.InvitationId);
+            var participant = invitation.Participants.Single(p => p.Id == request.ParticipantId);
+            invitation.UpdateNote(participant, request.Note, request.RowVersion);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return new SuccessResult<string>(participant.RowVersion.ConvertToString());
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandValidator.cs
@@ -11,8 +11,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipan
     {
         public UpdateNoteOnParticipantCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.Stop;
-            // todo ha sjekk for status til invitasjonen
+            CascadeMode = CascadeMode.Stop; 
+            
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) =>
                     BeAnExistingInvitation(command.InvitationId, cancellationToken))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandValidator.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators;
+using Equinor.ProCoSys.IPO.Command.Validators.RowVersionValidators;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using FluentValidation;
+
+namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant
+{
+    public class UpdateNoteOnParticipantCommandValidator : AbstractValidator<UpdateNoteOnParticipantCommand>
+    {
+        public UpdateNoteOnParticipantCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
+        {
+            CascadeMode = CascadeMode.Stop;
+            // todo ha sjekk for status til invitasjonen
+            RuleFor(command => command)
+                .MustAsync((command, cancellationToken) =>
+                    BeAnExistingInvitation(command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    $"Invitation with this ID does not exist! Id={command.InvitationId}")
+                .MustAsync((command, cancellationToken) =>
+                    NotBeCancelledInvitation(command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    $"Cannot perform updates on cancelled invitation! Id={command.InvitationId}")
+                .MustAsync((command, cancellationToken) =>
+                    BeAnExistingParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
+                .WithMessage(command =>
+                    $"Participant with ID does not exist on invitation! ParticipantId={command.ParticipantId}")
+                .Must(command => HaveAValidRowVersion(command.RowVersion))
+                .WithMessage(command =>
+                    $"Participant doesn't have valid rowVersion! ParticipantRowVersion={command.RowVersion}")
+                .MustAsync((command, cancellationToken) => HasPermissionToEditParticipant(command.ParticipantId, command.InvitationId, cancellationToken))
+                .WithMessage("The current user does not have sufficient privileges to edit this participant.");
+
+            async Task<bool> BeAnExistingInvitation(int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.IpoExistsAsync(invitationId, cancellationToken);
+
+            async Task<bool> NotBeCancelledInvitation(int invitationId, CancellationToken cancellationToken)
+                => !await invitationValidator.IpoIsInStageAsync(invitationId, IpoStatus.Canceled, cancellationToken);
+
+            async Task<bool> BeAnExistingParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.ParticipantExistsAsync(participantId, invitationId, cancellationToken);
+
+            async Task<bool> HasPermissionToEditParticipant(int participantId, int invitationId, CancellationToken cancellationToken)
+                => await invitationValidator.HasPermissionToEditParticipantAsync(participantId, invitationId, cancellationToken);
+
+            bool HaveAValidRowVersion(string rowVersion)
+                => rowVersionValidator.IsValid(rowVersion);
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
@@ -11,6 +11,9 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
         bool IsValidScope(DisciplineType type, IList<string> mcPkgScope, IList<string> commPkgScope);
         Task<bool> ParticipantWithIdExistsAsync(ParticipantsForCommand participant, int invitationId, CancellationToken token);
         Task<bool> ParticipantExistsAsync(int id, int invitationId, CancellationToken token);
+        Task<bool> IsSignedParticipantAsync(int id, int invitationId, CancellationToken token);
+        Task<bool> HasPermissionToEditParticipantAsync(int id, int invitationId, CancellationToken token);
+        Task<bool> HasOppositeAttendedStatusAsync(int id, int invitationId, bool attended, CancellationToken cancellationToken);
         bool IsValidParticipantList(IList<ParticipantsForCommand> participants);
         bool RequiredParticipantsMustBeInvited(IList<ParticipantsForCommand> participants);
         bool OnlyRequiredParticipantsHaveLowestSortKeys(IList<ParticipantsForCommand> participants);

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
@@ -11,7 +11,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
         bool IsValidScope(DisciplineType type, IList<string> mcPkgScope, IList<string> commPkgScope);
         Task<bool> ParticipantWithIdExistsAsync(ParticipantsForCommand participant, int invitationId, CancellationToken token);
         Task<bool> ParticipantExistsAsync(int id, int invitationId, CancellationToken token);
-        Task<bool> IsSignedParticipantAsync(int id, int invitationId, CancellationToken token);
+        Task<bool> ParticipantIsSignedAsync(int id, int invitationId, CancellationToken token);
         Task<bool> HasPermissionToEditParticipantAsync(int id, int invitationId, CancellationToken token);
         Task<bool> HasOppositeAttendedStatusAsync(int id, int invitationId, bool attended, CancellationToken cancellationToken);
         bool IsValidParticipantList(IList<ParticipantsForCommand> participants);

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/IInvitationValidator.cs
@@ -21,15 +21,15 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
         Task<bool> AttachmentWithFileNameExistsAsync(int invitationId, string fileName, CancellationToken cancellationToken);
         Task<bool> IpoExistsAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> IpoIsInStageAsync(int invitationId, IpoStatus stage, CancellationToken cancellationToken);
-        Task<bool> ValidCompleterParticipantExistsAsync(int invitationId, CancellationToken cancellationToken);
-        Task<bool> ValidAccepterParticipantExistsAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsValidCompleterParticipantAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsValidAccepterParticipantAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> IpoHasCompleterAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> IpoHasAccepterAsync(int invitationId, CancellationToken cancellationToken);
         Task<bool> SignerExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
-        Task<bool> ValidSigningParticipantExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
-        Task<bool> ValidUnsigningParticipantExistsAsync(int invitationId, int participantId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsValidSigningParticipantAsync(int invitationId, int participantId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsAdminOrValidUnsigningParticipantAsync(int invitationId, int participantId, CancellationToken cancellationToken);
         Task<bool> CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(int invitationId, CancellationToken cancellationToken);
-        Task<bool> AdminOrSameUserThatCompletedIsUnCompletingAsync(int invitationId, CancellationToken cancellationToken);
-        Task<bool> AdminOrSameUserThatAcceptedIsUnAcceptingAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsAdminOrValidCompletorParticipantAsync(int invitationId, CancellationToken cancellationToken);
+        Task<bool> CurrentUserIsAdminOrValidAccepterParticipantAsync(int invitationId, CancellationToken cancellationToken);
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
@@ -189,7 +189,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
 
         public async Task<bool> HasPermissionToEditParticipantAsync(int id, int invitationId, CancellationToken cancellationToken)
         {
-            if (await IsIpoAdmin()) { return true; }
+            if (await InvitationHelper.HasIpoAdminPrivilege(_permissionCache, _plantProvider, _currentUserProvider)) { return true; }
             var participant = await (from p in _context.QuerySet<Participant>()
                 where EF.Property<int>(p, "InvitationId") == invitationId &&
                       p.Id == id
@@ -212,12 +212,6 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
                 _currentUserProvider.GetCurrentUserOid().ToString(),
                 participant.FunctionalRoleCode);
             return person != null;
-        }
-
-        private async Task<bool> IsIpoAdmin()
-        {
-            var permissions = await _permissionCache.GetPermissionsForUserAsync(_plantProvider.Plant, _currentUserProvider.GetCurrentUserOid());
-            return permissions != null && permissions.Contains("IPO/ADMIN");
         }
 
         public async Task<bool> ParticipantWithIdExistsAsync(ParticipantsForCommand participant, int invitationId, CancellationToken cancellationToken)

--- a/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/Validators/InvitationValidators/InvitationValidator.cs
@@ -390,7 +390,7 @@ namespace Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators
                 // allow if user is member of contractor functional role
                 var contractorParticipants = await (from participant in _context.QuerySet<Participant>()
                                           where EF.Property<int>(participant, "InvitationId") == invitationId &&
-                                                participant.Organization == Organization.Contractor// && participant.SortKey == 0
+                                                participant.Organization == Organization.Contractor && participant.SortKey == 0
                                           select participant).ToListAsync(cancellationToken);
 
                 if (contractorParticipants.Any(p => p.FunctionalRoleCode != null))

--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/HistoryAggregate/EventType.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/HistoryAggregate/EventType.cs
@@ -29,6 +29,10 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.HistoryAggregate
         [Description("Comment removed")]
         CommentRemoved,
         [Description("IPO canceled")]
-        IpoCanceled
+        IpoCanceled,
+        [Description("Attended status updated")]
+        AttendedStatusUpdated,
+        [Description("Note updated")]
+        NoteUpdated
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/Invitation.cs
@@ -178,6 +178,34 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
             participant.SetRowVersion(participantRowVersion);
         }
 
+        public void UpdateNote(
+            Participant participant,
+            string note,
+            string participantRowVersion)
+        {
+            if (Status == IpoStatus.Canceled)
+            {
+                throw new Exception($"Update on {nameof(Invitation)} {Id} can not be performed. Status = {Status}");
+            }
+            participant.Note = note;
+            participant.SetRowVersion(participantRowVersion);
+            AddPreSaveDomainEvent(new NoteUpdatedEvent(Plant, ObjectGuid, note));
+        }
+        
+        public void UpdateAttendedStatus(
+            Participant participant,
+            bool attended,
+            string participantRowVersion)
+        {
+            if (Status == IpoStatus.Canceled)
+            {
+                throw new Exception($"Update on {nameof(Invitation)} {Id} can not be performed. Status = {Status}");
+            }
+            participant.Attended = attended;
+            participant.SetRowVersion(participantRowVersion);
+            AddPreSaveDomainEvent(new AttendedStatusUpdatedEvent(Plant, ObjectGuid));
+        }
+
         public void CompleteIpo(Participant participant, string participantRowVersion, Person completedBy, DateTime completedAtUtc)
         {
             if (participant == null)

--- a/src/Equinor.ProCoSys.IPO.Domain/Events/PreSave/AttendedStatusUpdatedEvent.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/Events/PreSave/AttendedStatusUpdatedEvent.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using MediatR;
+
+namespace Equinor.ProCoSys.IPO.Domain.Events.PreSave
+{
+    public class AttendedStatusUpdatedEvent : INotification
+    {
+        public AttendedStatusUpdatedEvent(
+            string plant,
+            Guid objectGuid)
+        {
+            Plant = plant;
+            ObjectGuid = objectGuid;
+        }
+        public string Plant { get; }
+        public Guid ObjectGuid { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Domain/Events/PreSave/NoteUpdatedEvent.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/Events/PreSave/NoteUpdatedEvent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using MediatR;
+
+namespace Equinor.ProCoSys.IPO.Domain.Events.PreSave
+{
+    public class NoteUpdatedEvent : INotification
+    {
+        public NoteUpdatedEvent(
+            string plant,
+            Guid objectGuid,
+            string note)
+        {
+            Plant = plant;
+            ObjectGuid = objectGuid;
+            Note = note;
+        }
+        public string Plant { get; }
+        public Guid ObjectGuid { get; }
+        public string Note { get; }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20220315084715_AddEventTypesForAttendedStatusAndNoteUpdates.Designer.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20220315084715_AddEventTypesForAttendedStatusAndNoteUpdates.Designer.cs
@@ -4,6 +4,7 @@ using Equinor.ProCoSys.IPO.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
 {
     [DbContext(typeof(IPOContext))]
-    partial class IPOContextModelSnapshot : ModelSnapshot
+    [Migration("20220315084715_AddEventTypesForAttendedStatusAndNoteUpdates")]
+    partial class AddEventTypesForAttendedStatusAndNoteUpdates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20220315084715_AddEventTypesForAttendedStatusAndNoteUpdates.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20220315084715_AddEventTypesForAttendedStatusAndNoteUpdates.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
+{
+    public partial class AddEventTypesForAttendedStatusAndNoteUpdates : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History",
+                sql: "EventType in ('IpoCompleted','IpoAccepted','IpoSigned','IpoUnsigned','IpoUncompleted','IpoUnaccepted','IpoCreated','IpoEdited','AttachmentUploaded','AttachmentRemoved','CommentAdded','CommentRemoved','IpoCanceled','AttendedStatusUpdated','NoteUpdated')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History",
+                sql: "EventType in ('IpoCompleted','IpoAccepted','IpoSigned','IpoUnsigned','IpoUncompleted','IpoUnaccepted','IpoCreated','IpoEdited','AttachmentUploaded','AttachmentRemoved','CommentAdded','CommentRemoved','IpoCanceled')");
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -224,7 +224,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         .Where(p => p.FunctionalRoleCode == participant.FunctionalRoleCode
                                     && p.SortKey == participant.SortKey
                                     && p.Type == IpoParticipantType.Person);
-                    var currentUserIsInFunctionalRole = CurrentUserIsInFunctionalRoleAsync(participant).Result;
+                    var currentUserIsInFunctionalRole = await CurrentUserIsInFunctionalRoleAsync(participant);
                     var canSign = ipoStatus != IpoStatus.Canceled && IsSigningParticipant(participant) && currentUserIsInFunctionalRole;
 
                     participantDtos.Add(new ParticipantDto(
@@ -238,7 +238,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         canSign,
                         canSign,
                         ipoStatus != IpoStatus.Canceled
-                            && (HasIpoAdminPrivilegeAsync().Result || currentUserNextRequiredSigner || (participant.SignedAtUtc == null && currentUserIsInFunctionalRole)),
+                            && (await HasIpoAdminPrivilegeAsync() || currentUserNextRequiredSigner || (participant.SignedAtUtc == null && currentUserIsInFunctionalRole)),
                         null,
                         null,
                         ConvertToFunctionalRoleDto(participant, personsInFunctionalRole),
@@ -259,7 +259,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                         canSign,
                         canSign,
                         ipoStatus != IpoStatus.Canceled
-                            && (HasIpoAdminPrivilegeAsync().Result || currentUserNextRequiredSigner || (participant.SignedAtUtc == null && currentUserIsParticipant)),
+                            && (await HasIpoAdminPrivilegeAsync() || currentUserNextRequiredSigner || (participant.SignedAtUtc == null && currentUserIsParticipant)),
                         null,
                         ConvertToInvitedPersonDto(participant),
                         null,

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -320,7 +320,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
                 _plantProvider.Plant,
                 new List<string> {participant.FunctionalRoleCode});
             var functionalRole = functionalRoles.SingleOrDefault();
-            
+
             return functionalRole?.Persons != null &&
                    functionalRole.Persons.Any(person =>
                        !string.IsNullOrEmpty(person.AzureOid) &&

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -46,7 +46,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public bool Attended { get; }
         [Obsolete("Use isSigner")]
         public bool CanSign { get; }
-        // IsSigner can be false even if the participant is in theory a signer, if the IPO is cancelled.
         public bool IsSigner { get; }
         public bool CanEditAttendedStatusAndNote { get; }
         public ExternalEmailDto ExternalEmail { get; }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -14,6 +14,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             string note,
             bool attended,
             bool canSign,
+            bool canEditAttendedStatusAndNote,
             ExternalEmailDto externalEmail,
             InvitedPersonDto person,
             FunctionalRoleDto functionalRole,
@@ -27,6 +28,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             Note = note;
             Attended = attended;
             CanSign = canSign;
+            CanEditAttendedStatusAndNote = canEditAttendedStatusAndNote;
             ExternalEmail = externalEmail;
             Person = person;
             FunctionalRole = functionalRole;
@@ -41,6 +43,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public string Note { get; }
         public bool Attended { get; }
         public bool CanSign { get; }
+        public bool CanEditAttendedStatusAndNote { get; }
         public ExternalEmailDto ExternalEmail { get; }
         public InvitedPersonDto Person { get; }
         public FunctionalRoleDto FunctionalRole { get; }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/ParticipantDto.cs
@@ -46,6 +46,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
         public bool Attended { get; }
         [Obsolete("Use isSigner")]
         public bool CanSign { get; }
+        // IsSigner can be false even if the participant is in theory a signer, if the IPO is cancelled.
         public bool IsSigner { get; }
         public bool CanEditAttendedStatusAndNote { get; }
         public ExternalEmailDto ExternalEmail { get; }

--- a/src/Equinor.ProCoSys.IPO.WebApi/AuthorizeAnyAttribute.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/AuthorizeAnyAttribute.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Equinor.ProCoSys.IPO.WebApi
+{
+    public class AuthorizeAnyAttribute : AuthorizeAttribute
+    {
+        public AuthorizeAnyAttribute()
+        {
+        }
+
+        public AuthorizeAnyAttribute(params string[] permissions) => Roles = string.Join(",", permissions);
+    }
+}

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
@@ -16,6 +16,8 @@ using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusAndNotesOnParticipants;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UploadAttachment;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Query.GetAttachmentById;
@@ -219,6 +221,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
             return this.FromResult(result);
         }
 
+        // TODO remove participants from DTO once new endpoints to update note and attended status are taken into use
         [Authorize(Roles = Permissions.IPO_SIGN)]
         [HttpPut("{id}/Accept")]
         public async Task<ActionResult<string>> AcceptPunchOut(
@@ -266,6 +269,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
             return this.FromResult(result);
         }
 
+        // TODO remove participants from DTO once new endpoints to update note and attended status are taken into use
         [Authorize(Roles = Permissions.IPO_SIGN)]
         [HttpPut("{id}/Complete")]
         public async Task<ActionResult<string>> CompletePunchOut(
@@ -289,7 +293,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
                 Console.WriteLine(e);
                 throw;
             }
-            
         }
 
         [Authorize(Roles = Permissions.IPO_SIGN)]
@@ -307,9 +310,39 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
             return this.FromResult(result);
         }
 
+        [AuthorizeAny(Permissions.IPO_WRITE, Permissions.IPO_SIGN, Permissions.IPO_ADMIN)]
+        [HttpPut("{id}/AttendedStatus")]
+        public async Task<ActionResult> UpdateAttendedStatusOnParticipant(
+            [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string plant,
+            [FromRoute] int id,
+            [FromBody] ParticipantToUpdateStatusDto dto)
+        {
+            var result = await _mediator.Send(new UpdateAttendedStatusOnParticipantCommand(id, dto.Id, dto.Attended, dto.RowVersion));
+            return this.FromResult(result);
+        }
+
+        [AuthorizeAny(Permissions.IPO_WRITE, Permissions.IPO_SIGN, Permissions.IPO_ADMIN)]
+        [HttpPut("{id}/Note")]
+        public async Task<ActionResult> UpdateNoteOnParticipant(
+            [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string plant,
+            [FromRoute] int id,
+            [FromBody] ParticipantToUpdateNoteDto dto)
+        {
+            var result = await _mediator.Send(
+                new UpdateNoteOnParticipantCommand(id, dto.Id, dto.Note, dto.RowVersion));
+            return this.FromResult(result);
+        }
+        
+        // TODO: This endpoint will be replaced by the two above, and this this endpoint can be removed once frontend stops using it.
         [Authorize(Roles = Permissions.IPO_SIGN)]
         [HttpPut("{id}/AttendedStatusAndNotes")]
-        public async Task<ActionResult> ChangeAttendedStatusOnParticipants(
+        public async Task<ActionResult> ChangeAttendedStatusAndNotesOnParticipants(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
@@ -434,6 +467,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
             return this.FromResult(result);
         }
 
+        #region Helpers
         private IList<ParticipantsForCommand> ConvertParticipantsForCreateCommands(IEnumerable<CreateParticipantDto> dto)
             => dto?.Select(p =>
                 new ParticipantsForCommand(
@@ -581,5 +615,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 
             return query;
         }
+        #endregion
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/ParticipantToUpdateStatusDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/ParticipantToUpdateStatusDto.cs
@@ -1,10 +1,9 @@
 ﻿namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 {
-    public class ParticipantToUpdateAttendedStatusAndNotesDto
+    public class ParticipantToUpdateStatusDto
     {
         public int Id { get; set; }
         public bool Attended { get; set; }
-        public string Note { get; set; }
         public string RowVersion { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Permissions.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Permissions.cs
@@ -15,5 +15,6 @@
         public const string IPO_ATTACHFILE = "IPO/ATTACHFILE";
         public const string IPO_DETACHFILE = "IPO/DETACHFILE";
         public const string IPO_VOIDUNVOID = "IPO/VOID/UNVOID";
+        public const string IPO_ADMIN = "IPO/ADMIN";
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/EventHandlers/HistoryEvents/AttendedStatusUpdatedEventHandlerTest.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/EventHandlers/HistoryEvents/AttendedStatusUpdatedEventHandlerTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Equinor.ProCoSys.IPO.Command.EventHandlers.HistoryEvents;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.HistoryAggregate;
+using Equinor.ProCoSys.IPO.Domain.Events.PreSave;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.EventHandlers.HistoryEvents
+{
+    [TestClass]
+    public class AttendedStatusUpdatedEventHandlerTests
+    {
+        private Mock<IHistoryRepository> _historyRepositoryMock;
+        private AttendedStatusUpdatedEventHandler _dut;
+        private History _historyAdded;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _historyRepositoryMock = new Mock<IHistoryRepository>();
+            _historyRepositoryMock
+                .Setup(repo => repo.Add(It.IsAny<History>()))
+                .Callback<History>(history =>
+                {
+                    _historyAdded = history;
+                });
+
+            _dut = new AttendedStatusUpdatedEventHandler(_historyRepositoryMock.Object);
+        }
+
+        [TestMethod]
+        public void Handle_ShouldUpdateAttendedStatusUpdatedHistoryRecord()
+        {
+            // Arrange
+            Assert.IsNull(_historyAdded);
+
+            // Act
+            var objectGuid = Guid.NewGuid();
+            var plant = "TestPlant";
+            _dut.Handle(new AttendedStatusUpdatedEvent(plant, objectGuid), default);
+
+            // Assert
+            Assert.IsNotNull(_historyAdded);
+            Assert.AreEqual(plant, _historyAdded.Plant);
+            Assert.AreEqual(objectGuid, _historyAdded.ObjectGuid);
+            Assert.IsNotNull(_historyAdded.Description);
+            Assert.AreEqual(EventType.AttendedStatusUpdated, _historyAdded.EventType);
+            Assert.AreEqual("IPO", _historyAdded.ObjectType);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/EventHandlers/HistoryEvents/NoteUpdatedEventHandlerTest.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/EventHandlers/HistoryEvents/NoteUpdatedEventHandlerTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Equinor.ProCoSys.IPO.Command.EventHandlers.HistoryEvents;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.HistoryAggregate;
+using Equinor.ProCoSys.IPO.Domain.Events.PreSave;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.EventHandlers.HistoryEvents
+{
+    [TestClass]
+    public class NoteUpdatedEventHandlerTests
+    {
+        private Mock<IHistoryRepository> _historyRepositoryMock;
+        private NoteUpdatedEventHandler _dut;
+        private History _historyAdded;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _historyRepositoryMock = new Mock<IHistoryRepository>();
+            _historyRepositoryMock
+                .Setup(repo => repo.Add(It.IsAny<History>()))
+                .Callback<History>(history =>
+                {
+                    _historyAdded = history;
+                });
+
+            _dut = new NoteUpdatedEventHandler(_historyRepositoryMock.Object);
+        }
+
+        [TestMethod]
+        public void Handle_ShouldUpdateNoteUpdatedHistoryRecord()
+        {
+            // Arrange
+            Assert.IsNull(_historyAdded);
+
+            // Act
+            var objectGuid = Guid.NewGuid();
+            var plant = "TestPlant";
+            var note = "Updated note";
+            _dut.Handle(new NoteUpdatedEvent(plant, objectGuid, note), default);
+
+            // Assert
+            Assert.IsNotNull(_historyAdded);
+            Assert.AreEqual(plant, _historyAdded.Plant);
+            Assert.AreEqual(objectGuid, _historyAdded.ObjectGuid);
+            Assert.IsNotNull(_historyAdded.Description);
+            Assert.AreEqual(EventType.NoteUpdated, _historyAdded.EventType);
+            Assert.AreEqual("IPO", _historyAdded.ObjectType);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Equinor.ProCoSys.IPO.Command.InvitationCommands;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
@@ -157,12 +156,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
                 _participantRowVersion,
                 _participantsToChange);
 
-            _dut = new AcceptPunchOutCommandHandler(
-                _plantProviderMock.Object,
-                _invitationRepositoryMock.Object,
+            _dut = new AcceptPunchOutCommandHandler(_invitationRepositoryMock.Object,
                 _unitOfWorkMock.Object,
                 _currentUserProviderMock.Object,
-                _personApiServiceMock.Object,
                 _personRepositoryMock.Object);
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandHandlerTests.cs
@@ -7,8 +7,6 @@ using Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.IPO.ForeignApi;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -18,11 +16,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
     [TestClass]
     public class AcceptPunchOutCommandHandlerTests
     {
-        private Mock<IPlantProvider> _plantProviderMock;
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
 
         private AcceptPunchOutCommand _command;
@@ -62,32 +58,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
         [TestInitialize]
         public void Setup()
         {
-            _plantProviderMock = new Mock<IPlantProvider>();
-            _plantProviderMock
-                .Setup(x => x.Plant)
-                .Returns(_plant);
-
             _unitOfWorkMock = new Mock<IUnitOfWork>();
 
             _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _currentUserProviderMock
                 .Setup(x => x.GetCurrentUserOid()).Returns(_azureOidForCurrentUser);
-
-            //mock person response from main API
-            var personDetails = new ProCoSysPerson
-            {
-                AzureOid = _azureOidForCurrentUser.ToString(),
-                FirstName = _firstName,
-                LastName = _lastName,
-                Email = "ola@test.com",
-                UserName = "ON"
-            };
-
-            _personApiServiceMock = new Mock<IPersonApiService>();
-            _personApiServiceMock
-                .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
-                    _azureOidForCurrentUser.ToString(), _functionalRoleCode))
-                .Returns(Task.FromResult(personDetails));
 
             //create invitation
             _invitation = new Invitation(

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidatorTests.cs
@@ -48,7 +48,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion2)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Completed, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidAccepterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidAccepterParticipantAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoHasAccepterAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId2, _id, default)).Returns(Task.FromResult(true));
@@ -120,7 +120,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.AcceptPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToAcceptIsNotAValidConstructionCompanyParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidAccepterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidAccepterParticipantAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidatorTests.cs
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion2)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Planned, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidCompleterParticipantAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId2, _id, default)).Returns(Task.FromResult(true));
@@ -123,7 +123,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CompletePunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToCompleteIsNotAValidContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidCompleterParticipantAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandHandlerTests.cs
@@ -7,8 +7,6 @@ using Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.IPO.ForeignApi;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -18,11 +16,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
     [TestClass]
     public class SignPunchOutCommandHandlerTests
     {
-        private Mock<IPlantProvider> _plantProviderMock;
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
 
         private SignPunchOutCommand _command;
@@ -42,33 +38,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
         [TestInitialize]
         public void Setup()
         {
-            _plantProviderMock = new Mock<IPlantProvider>();
-            _plantProviderMock
-                .Setup(x => x.Plant)
-                .Returns(_plant);
-
             _unitOfWorkMock = new Mock<IUnitOfWork>();
 
             _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _currentUserProviderMock
                 .Setup(x => x.GetCurrentUserOid()).Returns(_azureOidForCurrentUser);
-
-
-            //mock person response from main API
-            var personDetails = new ProCoSysPerson
-            {
-                AzureOid = _azureOidForCurrentUser.ToString(),
-                FirstName = "Kari",
-                LastName = "Nordman",
-                Email = "kari@test.com",
-                UserName = "KN"
-            };
-
-            _personApiServiceMock = new Mock<IPersonApiService>();
-            _personApiServiceMock
-                .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
-                    _azureOidForCurrentUser.ToString(), _functionalRoleCode))
-                .Returns(Task.FromResult(personDetails));
 
             //create invitation
             _invitation = new Invitation(
@@ -116,11 +90,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
                 _participantRowVersion);
 
             _dut = new SignPunchOutCommandHandler(
-                _plantProviderMock.Object,
                 _invitationRepositoryMock.Object,
                 _unitOfWorkMock.Object,
                 _currentUserProviderMock.Object,
-                _personApiServiceMock.Object,
                 _personRepositoryMock.Object);
         }
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_invitationId, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidSigningParticipantExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidSigningParticipantAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.SignerExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
             _command = new SignPunchOutCommand(
@@ -122,7 +122,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToCompleteIsNotAValidSigningParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidSigningParticipantExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidSigningParticipantAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
@@ -82,6 +82,19 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation is canceled, and thus cannot be signed"));
         }
 
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantIsSigned()
+        {
+            _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant is already signed!"));
+        }
+
         [TestMethod]
         public void Validate_ShouldFail_WhenParticipantRowVersionIsInvalid()
         {

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/SignPunchOut/SignPunchOutCommandValidatorTests.cs
@@ -86,7 +86,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.SignPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenParticipantIsSigned()
         {
-            _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ParticipantIsSignedAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnAcceptPunchOut
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Accepted, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.AdminOrSameUserThatAcceptedIsUnAcceptingAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidAccepterParticipantAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoHasAccepterAsync(_id, default)).Returns(Task.FromResult(true));
             _command = new UnAcceptPunchOutCommand(
                 _id,
@@ -98,7 +98,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnAcceptPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToUnAcceptIsNotThePersonWhoAcceptedTheIpoOrAnAdmin()
         {
-            _invitationValidatorMock.Setup(inv => inv.AdminOrSameUserThatAcceptedIsUnAcceptingAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidAccepterParticipantAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Equinor.ProCoSys.IPO.Command.InvitationCommands;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Completed, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.AdminOrSameUserThatCompletedIsUnCompletingAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidCompletorParticipantAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(true));
             _command = new UnCompletePunchOutCommand(
                 _id,
@@ -98,7 +98,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToUnCompleteIsNotThePersonWhoCompletedTheIpoOrAnAdmin()
         {
-            _invitationValidatorMock.Setup(inv => inv.AdminOrSameUserThatCompletedIsUnCompletingAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidCompletorParticipantAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutCommandHandlerTests.cs
@@ -7,8 +7,6 @@ using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut;
 using Equinor.ProCoSys.IPO.Domain;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.IPO.ForeignApi;
-using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
 using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -18,11 +16,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
     [TestClass]
     public class UnSignPunchOutCommandHandlerTests
     {
-        private Mock<IPlantProvider> _plantProviderMock;
         private Mock<IInvitationRepository> _invitationRepositoryMock;
         private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPersonApiService> _personApiServiceMock;
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
 
         private UnSignPunchOutCommand _command;
@@ -42,32 +38,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
         [TestInitialize]
         public void Setup()
         {
-            _plantProviderMock = new Mock<IPlantProvider>();
-            _plantProviderMock
-                .Setup(x => x.Plant)
-                .Returns(_plant);
-
             _unitOfWorkMock = new Mock<IUnitOfWork>();
 
             _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _currentUserProviderMock
                 .Setup(x => x.GetCurrentUserOid()).Returns(_azureOidForCurrentUser);
-
-            //mock person response from main API
-            var personDetails = new ProCoSysPerson
-            {
-                AzureOid = _azureOidForCurrentUser.ToString(),
-                FirstName = "Kari",
-                LastName = "Nordman",
-                Email = "kari@test.com",
-                UserName = "KN"
-            };
-
-            _personApiServiceMock = new Mock<IPersonApiService>();
-            _personApiServiceMock
-                .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
-                    _azureOidForCurrentUser.ToString(), _functionalRoleCode))
-                .Returns(Task.FromResult(personDetails));
 
             //create invitation
             _invitation = new Invitation(
@@ -117,13 +92,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
                 _participantId,
                 _participantRowVersion);
 
-            _dut = new UnSignPunchOutCommandHandler(
-                _plantProviderMock.Object,
-                _invitationRepositoryMock.Object,
-                _unitOfWorkMock.Object,
-                _currentUserProviderMock.Object,
-                _personApiServiceMock.Object,
-                _personRepositoryMock.Object);
+            _dut = new UnSignPunchOutCommandHandler(_invitationRepositoryMock.Object,
+                _unitOfWorkMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutValidatorTests.cs
@@ -30,6 +30,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
             _invitationValidatorMock.Setup(inv => inv.ValidSigningParticipantExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.SignerExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
+
             _command = new UnSignPunchOutCommand(
                 _invitationId,
                 _participantId,
@@ -79,7 +81,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation is canceled, and thus cannot be signed"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation is canceled, and thus cannot be unsigned"));
         }
 
         [TestMethod]
@@ -104,6 +106,18 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant is not assigned to unsign this IPO"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantIsNotSigned()
+        {
+            _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("An unsigned participant cannot be unsigned"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutValidatorTests.cs
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_invitationId, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidUnsigningParticipantExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.SignerExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
@@ -123,7 +123,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToCompleteIsNotAValidSigningParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidUnsigningParticipantExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnSignPunchOut/UnSignPunchOutValidatorTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
             _invitationValidatorMock.Setup(inv => inv.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.SignerExistsAsync(_invitationId, _participantId, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ParticipantIsSignedAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(true));
 
             _command = new UnSignPunchOutCommand(
                 _invitationId,
@@ -111,7 +111,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnSignPunchOut
         [TestMethod]
         public void Validate_ShouldFail_WhenParticipantIsNotSigned()
         {
-            _invitationValidatorMock.Setup(inv => inv.IsSignedParticipantAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.ParticipantIsSignedAsync(_participantId, _invitationId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandHandlerTests.cs
@@ -185,7 +185,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
         }
 
         [TestMethod]
-        public async Task HandlingCompleteIpoCommand_ShouldSetVersions()
+        public async Task HandlingUpdateAttendedStatusAndNotesOnParticipantsCommand_ShouldSetVersions()
         {
             // Act
             await _dut.Handle(_command, default);

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidatorTests.cs
@@ -48,7 +48,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
             _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion2)).Returns(true);
             _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_id, IpoStatus.Completed, default)).Returns(Task.FromResult(true));
-            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidCompleterParticipantAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.IpoHasCompleterAsync(_id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _id, default)).Returns(Task.FromResult(true));
             _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId2, _id, default)).Returns(Task.FromResult(true));
@@ -130,7 +130,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedSt
         [TestMethod]
         public void Validate_ShouldFail_WhenPersonTryingToCompleteIsNotAValidContractorParticipant()
         {
-            _invitationValidatorMock.Setup(inv => inv.ValidCompleterParticipantExistsAsync(_id, default)).Returns(Task.FromResult(false));
+            _invitationValidatorMock.Setup(inv => inv.CurrentUserIsValidCompleterParticipantAsync(_id, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandHandlerTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.IPO.ForeignApi;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
+using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedStatusOnParticipant
+{
+    [TestClass]
+    public class UpdateAttendedStatusOnParticipantCommandHandlerTests
+    {
+        private Mock<IPlantProvider> _plantProviderMock;
+        private Mock<IInvitationRepository> _invitationRepositoryMock;
+        private Mock<IPersonRepository> _personRepositoryMock;
+        private Mock<IUnitOfWork> _unitOfWorkMock;
+        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<ICurrentUserProvider> _currentUserProviderMock;
+
+        private UpdateAttendedStatusOnParticipantCommand _command;
+        private UpdateAttendedStatusOnParticipantCommandHandler _dut;
+        private const string _plant = "PCS$TEST_PLANT";
+        private const string _projectName = "Project name";
+        private const string _title = "Test title";
+        private const string _description = "Test description";
+        private const DisciplineType _typeDp = DisciplineType.DP;
+        private readonly Guid _meetingId = new Guid("11111111-2222-2222-2222-333333333333");
+        private const string _participantRowVersion = "AAAAAAAAABA=";
+        private static Guid _azureOidForCurrentUser = new Guid("11111111-1111-2222-3333-333333333334");
+        private const string _functionalRoleCode = "FR1";
+        private Invitation _invitation;
+        private const int _participantId = 10;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _plantProviderMock = new Mock<IPlantProvider>();
+            _plantProviderMock
+                .Setup(x => x.Plant)
+                .Returns(_plant);
+
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+
+            _currentUserProviderMock = new Mock<ICurrentUserProvider>();
+            _currentUserProviderMock
+                .Setup(x => x.GetCurrentUserOid()).Returns(_azureOidForCurrentUser);
+
+
+            //mock person response from main API
+            var personDetails = new ProCoSysPerson
+            {
+                AzureOid = _azureOidForCurrentUser.ToString(),
+                FirstName = "Kari",
+                LastName = "Nordman",
+                Email = "kari@test.com",
+                UserName = "KN"
+            };
+
+            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock
+                .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
+                    _azureOidForCurrentUser.ToString(), _functionalRoleCode))
+                .Returns(Task.FromResult(personDetails));
+
+            //create invitation
+            _invitation = new Invitation(
+                _plant,
+                _projectName,
+                _title,
+                _description,
+                _typeDp,
+                new DateTime(),
+                new DateTime(),
+                null,
+                new List<McPkg> { new McPkg(_plant, _projectName, "Comm", "Mc", "d", "1|2") },
+                null)
+            { MeetingId = _meetingId };
+            var participant = new Participant(
+                _plant,
+                Organization.Operation,
+                IpoParticipantType.FunctionalRole,
+                _functionalRoleCode,
+                null,
+                null,
+                null,
+                null,
+                null,
+                3);
+            participant.SetProtectedIdForTesting(_participantId);
+            _invitation.AddParticipant(participant);
+
+            _invitationRepositoryMock = new Mock<IInvitationRepository>();
+            _invitationRepositoryMock
+                .Setup(x => x.GetByIdAsync(It.IsAny<int>()))
+                .Returns(Task.FromResult(_invitation));
+
+            var currentUser = new Person(_azureOidForCurrentUser, null, null, null, null);
+            currentUser.SetProtectedIdForTesting(_participantId);
+
+            _personRepositoryMock = new Mock<IPersonRepository>();
+            _personRepositoryMock
+                .Setup(x => x.GetByOidAsync(It.IsAny<Guid>()))
+                .Returns(Task.FromResult(currentUser));
+
+            //command
+            _command = new UpdateAttendedStatusOnParticipantCommand(
+                _invitation.Id,
+                _participantId,
+                true,
+                _participantRowVersion);
+
+            _dut = new UpdateAttendedStatusOnParticipantCommandHandler(
+                _invitationRepositoryMock.Object,
+                _unitOfWorkMock.Object);
+        }
+
+        [TestMethod]
+        public async Task UpdateAttendedStatusCommand_ShouldUpdateAttendedStatus()
+        {
+            var participant = _invitation.Participants.Single(p => p.Id == _participantId);
+            Assert.IsFalse(participant.Attended);
+
+            await _dut.Handle(_command, default);
+
+            Assert.IsTrue(participant.Attended);
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateAttendedStatusCommand_ShouldSetAndReturnRowVersion()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
+            Assert.AreEqual(_participantRowVersion, result.Data);
+            Assert.AreEqual(_participantRowVersion, _invitation.Participants.Single(p => p.Id == _participantId).RowVersion.ConvertToString());
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandTests.cs
@@ -1,0 +1,25 @@
+﻿using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedStatusOnParticipant
+{
+    [TestClass]
+    public class UpdateAttendedStatusOnParticipantCommandTests
+    {
+        private const string ParticipantRowVersion = "AAAAAAAAABB=";
+        [TestMethod]
+        public void Constructor_SetsProperties()
+        {
+            var dut = new UpdateAttendedStatusOnParticipantCommand(
+                1,
+                2,
+                true,
+                ParticipantRowVersion);
+
+            Assert.AreEqual(1, dut.InvitationId);
+            Assert.AreEqual(ParticipantRowVersion, dut.RowVersion);
+            Assert.AreEqual(2, dut.ParticipantId);
+            Assert.IsTrue(dut.Attended);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateAttendedStatusOnParticipant/UpdateAttendedStatusOnParticipantCommandValidatorTests.cs
@@ -1,0 +1,118 @@
+﻿using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant;
+using Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators;
+using Equinor.ProCoSys.IPO.Command.Validators.RowVersionValidators;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateAttendedStatusOnParticipant
+{
+    [TestClass]
+    public class UpdateAttendedStatusOnParticipantCommandValidatorTests
+    {
+        private UpdateAttendedStatusOnParticipantCommandValidator _dut;
+        private Mock<IInvitationValidator> _invitationValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
+
+        private UpdateAttendedStatusOnParticipantCommand _command;
+        private const bool _attended = true;
+        private const int _invitationId = 1;
+        private const int _participantId1 = 10;
+        private const string _participantRowVersion1 = "AAAAAAAAABB=";
+
+        [TestInitialize]
+        public void Setup_OkState()
+        {
+            _invitationValidatorMock = new Mock<IInvitationValidator>();
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion1)).Returns(true);
+            _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.HasPermissionToEditParticipantAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.HasOppositeAttendedStatusAsync(_participantId1, _invitationId, _attended, default)).Returns(Task.FromResult(true));
+            _command = new UpdateAttendedStatusOnParticipantCommand(_invitationId, _participantId1, _attended, _participantRowVersion1);
+            _dut = new UpdateAttendedStatusOnParticipantCommandValidator(_invitationValidatorMock.Object, _rowVersionValidatorMock.Object);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldBeValid_WhenOkState()
+        {
+            var result = _dut.Validate(_command);
+
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvitationIdIsNonExisting()
+        {
+            _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantIdIsNonExisting()
+        {
+            _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant with ID does not exist on invitation"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantDoesNotHavePermissionToEdit()
+        {
+            _invitationValidatorMock.Setup(inv => inv.HasPermissionToEditParticipantAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("The current user does not have sufficient privileges to edit this participant."));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenCurrentAttendedStatusIsTheSameAsStatusInRequest()
+        {
+            _invitationValidatorMock.Setup(inv => inv.HasOppositeAttendedStatusAsync(_participantId1, _invitationId, _attended, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Cannot update participant to its current attendedStatus."));
+        }
+        
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvitationIsCancelled()
+        {
+            _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_invitationId, IpoStatus.Canceled, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Cannot perform updates on cancelled invitation"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantRowVersionIsInvalid()
+        {
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion1)).Returns(false);
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant doesn't have valid rowVersion"));
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandHandlerTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant;
+using Equinor.ProCoSys.IPO.Domain;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.IPO.ForeignApi;
+using Equinor.ProCoSys.IPO.ForeignApi.MainApi.Person;
+using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateNoteOnParticipant
+{
+    [TestClass]
+    public class UpdateNoteOnParticipantCommandHandlerTests
+    {
+        private Mock<IPlantProvider> _plantProviderMock;
+        private Mock<IInvitationRepository> _invitationRepositoryMock;
+        private Mock<IPersonRepository> _personRepositoryMock;
+        private Mock<IUnitOfWork> _unitOfWorkMock;
+        private Mock<IPersonApiService> _personApiServiceMock;
+        private Mock<ICurrentUserProvider> _currentUserProviderMock;
+
+        private UpdateNoteOnParticipantCommand _command;
+        private UpdateNoteOnParticipantCommandHandler _dut;
+        private const string _plant = "PCS$TEST_PLANT";
+        private const string _projectName = "Project name";
+        private const string _title = "Test title";
+        private const string _description = "Test description";
+        private const DisciplineType _typeDp = DisciplineType.DP;
+        private readonly Guid _meetingId = new Guid("11111111-2222-2222-2222-333333333333");
+        private const string _participantRowVersion = "AAAAAAAAABA=";
+        private static Guid _azureOidForCurrentUser = new Guid("11111111-1111-2222-3333-333333333334");
+        private const string _functionalRoleCode = "FR1";
+        private Invitation _invitation;
+        private const int _participantId = 10;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _plantProviderMock = new Mock<IPlantProvider>();
+            _plantProviderMock
+                .Setup(x => x.Plant)
+                .Returns(_plant);
+
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+
+            _currentUserProviderMock = new Mock<ICurrentUserProvider>();
+            _currentUserProviderMock
+                .Setup(x => x.GetCurrentUserOid()).Returns(_azureOidForCurrentUser);
+
+
+            //mock person response from main API
+            var personDetails = new ProCoSysPerson
+            {
+                AzureOid = _azureOidForCurrentUser.ToString(),
+                FirstName = "Kari",
+                LastName = "Nordman",
+                Email = "kari@test.com",
+                UserName = "KN"
+            };
+
+            _personApiServiceMock = new Mock<IPersonApiService>();
+            _personApiServiceMock
+                .Setup(x => x.GetPersonInFunctionalRoleAsync(_plant,
+                    _azureOidForCurrentUser.ToString(), _functionalRoleCode))
+                .Returns(Task.FromResult(personDetails));
+
+            //create invitation
+            _invitation = new Invitation(
+                _plant,
+                _projectName,
+                _title,
+                _description,
+                _typeDp,
+                new DateTime(),
+                new DateTime(),
+                null,
+                new List<McPkg> { new McPkg(_plant, _projectName, "Comm", "Mc", "d", "1|2") },
+                null)
+            { MeetingId = _meetingId };
+            var participant = new Participant(
+                _plant,
+                Organization.Operation,
+                IpoParticipantType.FunctionalRole,
+                _functionalRoleCode,
+                null,
+                null,
+                null,
+                null,
+                null,
+                3);
+            participant.SetProtectedIdForTesting(_participantId);
+            _invitation.AddParticipant(participant);
+
+            _invitationRepositoryMock = new Mock<IInvitationRepository>();
+            _invitationRepositoryMock
+                .Setup(x => x.GetByIdAsync(It.IsAny<int>()))
+                .Returns(Task.FromResult(_invitation));
+
+            var currentUser = new Person(_azureOidForCurrentUser, null, null, null, null);
+            currentUser.SetProtectedIdForTesting(_participantId);
+
+            _personRepositoryMock = new Mock<IPersonRepository>();
+            _personRepositoryMock
+                .Setup(x => x.GetByOidAsync(It.IsAny<Guid>()))
+                .Returns(Task.FromResult(currentUser));
+
+            //command
+            _command = new UpdateNoteOnParticipantCommand(
+                _invitation.Id,
+                _participantId,
+                "note",
+                _participantRowVersion);
+
+            _dut = new UpdateNoteOnParticipantCommandHandler(
+                _invitationRepositoryMock.Object,
+                _unitOfWorkMock.Object);
+        }
+
+        [TestMethod]
+        public async Task UpdateNoteCommand_ShouldUpdateNote()
+        {
+            var participant = _invitation.Participants.Single(p => p.Id == _participantId);
+            Assert.IsNull(participant.Note);
+
+            await _dut.Handle(_command, default);
+
+            Assert.IsNotNull(participant.Note);
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateNoteCommand_ShouldSetAndReturnRowVersion()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
+            Assert.AreEqual(_participantRowVersion, result.Data);
+            Assert.AreEqual(_participantRowVersion, _invitation.Participants.Single(p => p.Id == _participantId).RowVersion.ConvertToString());
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandTests.cs
@@ -1,0 +1,25 @@
+﻿using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateNoteOnParticipant
+{
+    [TestClass]
+    public class UpdateNoteOnParticipantCommandTests
+    {
+        private const string ParticipantRowVersion = "AAAAAAAAABB=";
+        [TestMethod]
+        public void Constructor_SetsProperties()
+        {
+            var dut = new UpdateNoteOnParticipantCommand(
+                1,
+                2,
+                "note",
+                ParticipantRowVersion);
+
+            Assert.AreEqual(1, dut.InvitationId);
+            Assert.AreEqual(ParticipantRowVersion, dut.RowVersion);
+            Assert.AreEqual(2, dut.ParticipantId);
+            Assert.AreEqual("note", dut.Note);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateNoteOnParticipant/UpdateNoteOnParticipantCommandValidatorTests.cs
@@ -1,0 +1,106 @@
+﻿using System.Threading.Tasks;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant;
+using Equinor.ProCoSys.IPO.Command.Validators.InvitationValidators;
+using Equinor.ProCoSys.IPO.Command.Validators.RowVersionValidators;
+using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateNoteOnParticipant
+{
+    [TestClass]
+    public class UpdateNoteOnParticipantCommandValidatorTests
+    {
+        private UpdateNoteOnParticipantCommandValidator _dut;
+        private Mock<IInvitationValidator> _invitationValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
+
+        private UpdateNoteOnParticipantCommand _command;
+        private const string _note = "note";
+        private const int _invitationId = 1;
+        private const int _participantId1 = 10;
+        private const string _participantRowVersion1 = "AAAAAAAAABB=";
+
+        [TestInitialize]
+        public void Setup_OkState()
+        {
+            _invitationValidatorMock = new Mock<IInvitationValidator>();
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion1)).Returns(true);
+            _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(true));
+            _invitationValidatorMock.Setup(inv => inv.HasPermissionToEditParticipantAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(true));
+            _command = new UpdateNoteOnParticipantCommand(_invitationId, _participantId1, _note, _participantRowVersion1);
+            _dut = new UpdateNoteOnParticipantCommandValidator(_invitationValidatorMock.Object, _rowVersionValidatorMock.Object);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldBeValid_WhenOkState()
+        {
+            var result = _dut.Validate(_command);
+
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvitationIdIsNonExisting()
+        {
+            _invitationValidatorMock.Setup(inv => inv.IpoExistsAsync(_invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Invitation with this ID does not exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantIdIsNonExisting()
+        {
+            _invitationValidatorMock.Setup(inv => inv.ParticipantExistsAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant with ID does not exist on invitation"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantDoesNotHavePermissionToEdit()
+        {
+            _invitationValidatorMock.Setup(inv => inv.HasPermissionToEditParticipantAsync(_participantId1, _invitationId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("The current user does not have sufficient privileges to edit this participant."));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvitationIsCancelled()
+        {
+            _invitationValidatorMock.Setup(inv => inv.IpoIsInStageAsync(_invitationId, IpoStatus.Canceled, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Cannot perform updates on cancelled invitation"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenParticipantRowVersionIsInvalid()
+        {
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_participantRowVersion1)).Returns(false);
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Participant doesn't have valid rowVersion"));
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -18,6 +18,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
     [TestClass]
     public class InvitationValidatorTests : ReadOnlyTestsBase
     {
+        #region Setup
         private const string _projectName = "Project name";
         private const string _projectName2 = "Project name 2";
         private const string _title1 = "Test title";
@@ -402,6 +403,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             }
         }
 
+        #endregion
+
+        #region IsValidScope
         [TestMethod]
         public void IsValidScope_McPkgScopeOnlyOnDp_ReturnsTrue()
         {
@@ -489,7 +493,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region RequiredParticipantsMustBeInvited
         [TestMethod]
         public void RequiredParticipantsMustBeInvited_RequiredParticipantsInvited_ReturnsTrue()
         {
@@ -572,7 +578,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         }
 
         [TestMethod]
-        public void IsValidParticipantList_OnlyRequiredParticipantsList_ReturnsTrue()
+        public void RequiredParticipantsMustBeInvited_OnlyRequiredParticipantsList_ReturnsTrue()
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -581,7 +587,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsTrue(result);
             }
         }
+        #endregion
 
+        #region IsValidParticipantList
         [TestMethod]
         public void IsValidParticipantList_ParticipantsWithoutParticipantInvited_ReturnsFalse()
         {
@@ -833,7 +841,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region OnlyRequiredParticipantsHaveLowestSortKeys
         [TestMethod]
         public void OnlyRequiredParticipantsHaveLowestSortKeys_OnlyRequiredParticipantsInvited_ReturnsTrue()
         {
@@ -908,7 +918,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region ParticipantWithIdExists
         [TestMethod]
         public async Task ParticipantWithIdExistsAsync_ExternalParticipantHasIdAndExists_ReturnsTrue()
         {
@@ -1050,10 +1062,10 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ParticipantMustHaveId_FunctionalRoleWithPersonsWithIdDoesntExist_ReturnsFalse()
+        public async Task ParticipantWithIdExistsAsync_FunctionalRoleWithPersonsWithIdDoesntExist_ReturnsFalse()
         {
             using (var context =
-                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var functionalRole =
@@ -1075,7 +1087,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region IpoExists
         [TestMethod]
         public async Task IpoExistsAsync_ExistingInvitationId_ReturnsTrue()
         {
@@ -1099,9 +1113,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region CurrentUserIsValidAccepterParticipant
         [TestMethod]
-        public async Task ValidAccepterParticipantExistsAsync_FunctionalRoleAsAccepter_ReturnsTrue()
+        public async Task CurrentUserIsValidAccepterParticipantAsync_FunctionalRoleAsAccepter_ReturnsTrue()
         {
             _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
                     TestPlant,
@@ -1113,47 +1129,49 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                var result = await dut.CurrentUserIsValidAccepterParticipantAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidAccepterParticipantExistsAsync_PersonNotInFunctionalRole_ReturnsFalse()
+        public async Task CurrentUserIsValidAccepterParticipantAsync_PersonNotInFunctionalRole_ReturnsFalse()
         {
             using (var context =
                    new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                var result = await dut.CurrentUserIsValidAccepterParticipantAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidAccepterParticipantExistsAsync_PersonAsAccepter_ReturnsTrue()
+        public async Task CurrentUserIsValidAccepterParticipantAsync_PersonAsAccepter_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsValidAccepterParticipantAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidAccepterParticipantExistsAsync_AccepterPersonIsntCurrentUser_ReturnsFalse()
+        public async Task CurrentUserIsValidAccepterParticipantAsync_AccepterPersonIsntCurrentUser_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsValidAccepterParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region IpoHasAccepter
         [TestMethod]
         public async Task IpoHasAccepterAsync_AccepterExists_ReturnsTrue()
         {
@@ -1177,7 +1195,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region ParticipantExists
         [TestMethod]
         public async Task ParticipantExistsAsync_ParticipantExists_ReturnsTrue()
         {
@@ -1201,6 +1221,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
+
+        #region BeSignedParticipant
 
         [TestMethod]
         public async Task BeSignedParticipantAsync_ParticipantIsSigned_ReturnsTrue()
@@ -1225,10 +1248,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
-
+        #region CurrentUserIsValidCompleterParticipant
         [TestMethod]
-        public async Task ValidCompleterParticipantExistsAsyncAsync_FunctionalRoleAsCompleter_ReturnsTrue()
+        public async Task CurrentUserIsValidCompleterParticipantAsync_FunctionalRoleAsCompleter_ReturnsTrue()
         {
             _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
                     TestPlant,
@@ -1240,47 +1264,49 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                var result = await dut.CurrentUserIsValidCompleterParticipantAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidCompleterParticipantExistsAsyncAsync_PersonNotInFunctionalRole_ReturnsFalse()
+        public async Task CurrentUserIsValidCompleterParticipantAsync_PersonNotInFunctionalRole_ReturnsFalse()
         {
             using (var context =
                    new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                var result = await dut.CurrentUserIsValidCompleterParticipantAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidCompleterParticipantExistsAsync_PersonAsCompleter_ReturnsTrue()
+        public async Task CurrentUserIsValidCompleterParticipantAsync_PersonAsCompleter_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsValidCompleterParticipantAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidCompleterParticipantExistsAsync_CompleterPersonIsntCurrentUser_ReturnsFalse()
+        public async Task CurrentUserIsValidCompleterParticipantAsync_CompleterPersonIsntCurrentUser_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsValidCompleterParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region IpoHasCompleter
         [TestMethod]
         public async Task IpoHasCompleterAsync_CompleterExists_ReturnsTrue()
         {
@@ -1304,77 +1330,96 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region CurrentUserIsValidSigningParticipant
         [TestMethod]
-        public async Task ValidSignerParticipantExistsAsync_FunctionalRoleAsSigner_ReturnsTrue()
+        public async Task CurrentUserIsValidSigningParticipantAsync_UserIsNotInFunctionalRole_ReturnsFalse()
         {
             using (var context =
-                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
-                Assert.IsTrue(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task ValidSignerParticipantExistsAsync_PersonAsSigner_ReturnsTrue()
-        {
-            using (var context =
-                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
-                Assert.IsTrue(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task ValidSignerParticipantExistsAsync_SignerPersonIsntCurrentUser_ReturnsFalse()
-        {
-            using (var context =
-                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
+                var result = await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidSignerParticipantExistsAsync_ShouldThrowException_WhenSignerIsContractor()
+        public async Task CurrentUserIsValidSigningParticipantAsync_FunctionalRoleAsSigner_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code op"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson { AzureOid = _currentUserOid.ToString() }));
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsValidSigningParticipantAsync_PersonAsSigner_ReturnsTrue()
+        {
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsValidSigningParticipantAsync_SignerPersonIsntCurrentUser_ReturnsFalse()
+        {
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsValidSigningParticipantAsync_ShouldThrowException_WhenSignerIsFirstContractor()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
-                    await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _contractorId, default)
+                    await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _contractorId, default)
                 );
                 Assert.AreEqual(result.Message, "Sequence contains no elements");
             }
         }
 
         [TestMethod]
-        public async Task ValidSignerParticipantExistsAsync_SignerIsCommissioning_ReturnsTrue()
+        public async Task CurrentUserIsValidSigningParticipantAsync_SignerIsCommissioning_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _commissioningId, default);
+                var result = await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _commissioningId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidSignerParticipantExistsAsync_SignerIsAdditionalContractor_ReturnsTrue()
+        public async Task CurrentUserIsValidSigningParticipantAsync_SignerIsAdditionalContractor_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _additionalContractorId, default);
+                var result = await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _additionalContractorId, default);
                 Assert.IsTrue(result);
             }
         }
@@ -1387,100 +1432,121 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
-                    await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _supplierId, default)
+                    await dut.CurrentUserIsValidSigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _supplierId, default)
                 );
                 Assert.AreEqual(result.Message, "Sequence contains no elements");
             }
         }
+        #endregion
 
+        #region CurrentUserIsAdminOrValidUnsigningParticipant
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_FunctionalRoleAsUnsigner_ReturnsTrue()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_UserNotInFunctionalRole_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
+                var result = await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
+                Assert.IsFalse(result);
+            }
+        }
+        
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_FunctionalRoleAsUnsigner_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code op"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson { AzureOid = _currentUserOid.ToString() }));
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_PersonAsUnsigner_ReturnsTrue()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_PersonAsUnsigner_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
+                var result = await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_UnsignerPersonIsntCurrentUser_ReturnsFalse()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_UnsignerPersonIsntCurrentUser_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
+                var result = await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_ShouldThrowException_WhenUnsignerIsContractor()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_ShouldThrowException_WhenUnsignerIsContractor()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
-                    await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _contractorId, default)
+                    await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _contractorId, default)
                 );
                 Assert.AreEqual(result.Message, "Sequence contains no elements");
             }
         }
 
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_UnsignerIsCommissioning_ReturnsTrue()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_UnsignerIsCommissioning_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _commissioningId, default);
+                var result = await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _commissioningId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_UnsignerIsAdmin_ReturnsTrue()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_UnsignerIsAdmin_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCacheForAdmin);
-                var result = await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
+                var result = await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task ValidUnsignerParticipantExistsAsync_ShouldThrowException_WhenUnsignerIsSupplier()
+        public async Task CurrentUserIsAdminOrValidUnsigningParticipantAsync_ShouldThrowException_WhenUnsignerIsSupplier()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
-                    await dut.ValidUnsigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _supplierId, default)
+                    await dut.CurrentUserIsAdminOrValidUnsigningParticipantAsync(_invitationIdWithValidAndNonValidSignerParticipants, _supplierId, default)
                 );
                 Assert.AreEqual(result.Message, "Sequence contains no elements");
             }
         }
+        #endregion
 
+        #region SignerExists
         [TestMethod]
         public async Task SignerExistsAsync_SignerExists_ReturnsTrue()
         {
@@ -1504,9 +1570,11 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation
         [TestMethod]
-        public async Task CurrentUserIsCreatorOfInvitation_CurrentUserIsCreator_ReturnsTrue()
+        public async Task CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation_CurrentUserIsCreator_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -1518,7 +1586,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task CurrentUserIsCreatorOfInvitation_CurrentUserIsNotCreator_ReturnsFalse()
+        public async Task CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation_CurrentUserIsNotCreator_ReturnsFalse()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -1530,7 +1598,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task CurrentUserIsNotCreatorOfInvitationButContractor_ReturnsTrue()
+        public async Task CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation_CurrentUserIsNotCreatorOfInvitationButContractor_ReturnsTrue()
         {
             _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
                 TestPlant,
@@ -1548,7 +1616,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task CurrentUserIsNotCreatorOfInvitationAndNotContractor_ReturnsFalse()
+        public async Task CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitation_CurrentUserIsNotCreatorOfInvitationAndNotContractor_ReturnsFalse()
         {
             _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(TestPlant, _currentUserOid.ToString(), "Contractor")).Returns(Task.FromResult<ForeignApi.ProCoSysPerson>(null));
 
@@ -1560,7 +1628,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region IpoIsInStage
         [TestMethod]
         public async Task IpoIsInStageAsync_IpoIsInPlannedStage_ReturnsTrue()
         {
@@ -1608,45 +1678,146 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
 
+        #region CurrentUserIsAdminOrValidCompletorParticipant
         [TestMethod]
-        public async Task AdminOrSameUserThatCompletedIsUnCompletingAsync_UserIsAdmin_ReturnsTrue()
+        public async Task CurrentUserIsAdminOrValidCompletorParticipantAsync_UserIsAdmin_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCacheForAdmin);
-                var result = await dut.AdminOrSameUserThatCompletedIsUnCompletingAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsAdminOrValidCompletorParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task AdminOrSameUserUnAcceptingThatAcceptedAsync_SameUser_ReturnsTrue()
+        public async Task CurrentUserIsAdminOrValidCompletorParticipantAsync_SameUser_ReturnsTrue()
         {
             using (var context =
-                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.AdminOrSameUserThatAcceptedIsUnAcceptingAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsAdminOrValidCompletorParticipantAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task AdminOrSameUserUnAcceptingThatAcceptedAsync_DifferentUser_ReturnsFalse()
+        public async Task CurrentUserIsAdminOrValidCompletorParticipantAsync_DifferentUser_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidCompletorParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidCompletorParticipantAsync_FunctionalRoleAsCompleter_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
+
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidCompletorParticipantAsync(_invitationIdWithFrAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidCompletorParticipantAsync_NotInFr_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidCompletorParticipantAsync(_invitationIdWithFrAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+        #endregion
+
+        #region CurrentUserIsAdminOrValidAcceptorParticipant
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidAccepterParticipantAsync_UserIsAdmin_ReturnsTrue()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCacheForAdmin);
+                var result = await dut.CurrentUserIsAdminOrValidAccepterParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidAccepterParticipantAsync_SameUser_ReturnsTrue()
         {
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.AdminOrSameUserThatAcceptedIsUnAcceptingAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
+                var result = await dut.CurrentUserIsAdminOrValidAccepterParticipantAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidAccepterParticipantAsync_DifferentUser_ReturnsFalse()
+        {
+            using (var context =
+                new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidAccepterParticipantAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 //This is not a full test coverage, because we do not have a history event for this accepting. We get false because there are not history events in this validation. Cannot add history event that is created by a user other than current user
                 Assert.IsFalse(result);
             }
         }
 
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidAccepterParticipantAsync_FunctionalRoleAsAccepter_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code 2"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
 
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidAccepterParticipantAsync(_invitationIdWithFrAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task CurrentUserIsAdminOrValidAccepterParticipantAsync_PersonNotInFunctionalRole_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.CurrentUserIsAdminOrValidAccepterParticipantAsync(_invitationIdWithFrAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+        #endregion
+
+        #region HasPermissionToEditParticipant
         [TestMethod]
         public async Task HasPermissionToEditParticipantAsync_ParticipantIsCurrentUser_ReturnsTrue()
         {
@@ -1717,7 +1888,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             }
         }
 
-
         [TestMethod]
         public async Task HasPermissionToEditParticipantAsync_UserIsFirstContractor_ReturnsTrue()
         {
@@ -1763,7 +1933,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
-        
+        #endregion
+
+        #region HasOppositeAttendedStatus
         [TestMethod]
         public async Task HasOppositeAttendedStatusAsync_ParticipantHasOppositeAttendedStatus_ReturnsTrue()
         {
@@ -1787,5 +1959,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+        #endregion
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -1551,6 +1551,34 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             }
         }
 
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_ParticipantHasSigned_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasPermissionToEditParticipantAsync(_participantId2, _invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_ParticipantHasSignedButIsAdmin_ReturnsTrue()
+        {
+            var permissionCacheMock = new Mock<IPermissionCache>();
+            IList<string> ipoAdminPrivilege = new List<string> { "IPO/ADMIN" };
+            permissionCacheMock
+                .Setup(x => x.GetPermissionsForUserAsync(_plantProvider.Plant, _currentUserOid))
+                .Returns(Task.FromResult(ipoAdminPrivilege));
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, permissionCacheMock.Object);
+                var result = await dut.HasPermissionToEditParticipantAsync(_participantId2, _invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
 
         [TestMethod]
         public async Task HasPermissionToEditParticipantAsync_UserIsIpoAdmin_ReturnsTrue()

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -1232,7 +1232,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                    new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.IsSignedParticipantAsync(_participantId2, _invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.ParticipantIsSignedAsync(_participantId2, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
         }
@@ -1244,7 +1244,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                    new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
-                var result = await dut.IsSignedParticipantAsync(_operationCurrentPersonId, _invitationIdWithCurrentUserOidAsParticipants, default);
+                var result = await dut.ParticipantIsSignedAsync(_operationCurrentPersonId, _invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
         }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/Validators/InvitationValidatorTests.cs
@@ -41,6 +41,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         private int _commissioningId;
         private int _additionalContractorId;
         private int _supplierId;
+        private int _contractorFrId;
+        private int _constructionCompanyFrId;
         private const string _description = "Test description";
         private const DisciplineType _typeDp = DisciplineType.DP;
         private const DisciplineType _typeMdp = DisciplineType.MDP;
@@ -387,6 +389,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
                 _commissioningId = commissioningParticipant.Id;
                 _additionalContractorId = additionalContractorParticipant.Id;
                 _supplierId = supplierParticipant.Id;
+                _contractorFrId = frContractor.Id;
+                _constructionCompanyFrId = frConstructionCompany.Id;
             }
         }
 
@@ -395,7 +399,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeDp, _mcPkgScope, new List<string>());
                 Assert.IsTrue(result);
             }
@@ -406,7 +410,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeMdp, new List<string>(), _commPkgScope);
                 Assert.IsTrue(result);
             }
@@ -417,7 +421,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeMdp, _mcPkgScope, new List<string>());
                 Assert.IsFalse(result);
             }
@@ -428,7 +432,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeDp, new List<string>(), _commPkgScope);
                 Assert.IsFalse(result);
             }
@@ -439,7 +443,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeDp, _mcPkgScope, _commPkgScope);
                 Assert.IsFalse(result);
             }
@@ -450,7 +454,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeMdp, _mcPkgScope, _commPkgScope);
                 Assert.IsFalse(result);
             }
@@ -461,7 +465,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeDp, new List<string>(), new List<string>());
                 Assert.IsFalse(result);
             }
@@ -472,7 +476,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidScope(_typeMdp, new List<string>(), new List<string>());
                 Assert.IsFalse(result);
             }
@@ -483,7 +487,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.RequiredParticipantsMustBeInvited(_participantsOnlyRequired);
                 Assert.IsTrue(result);
             }
@@ -494,7 +498,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand>());
                 Assert.IsFalse(result);
             }
@@ -505,7 +509,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand> {
                     new ParticipantsForCommand(
                         Organization.Contractor,
@@ -529,7 +533,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand> { _participantsOnlyRequired[0] });
                 Assert.IsFalse(result);
             }
@@ -540,7 +544,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.RequiredParticipantsMustBeInvited(new List<ParticipantsForCommand> {
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -564,7 +568,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.RequiredParticipantsMustBeInvited(_participantsOnlyRequired);
                 Assert.IsTrue(result);
             }
@@ -575,7 +579,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidParticipantList(new List<ParticipantsForCommand> {
                     _participantsOnlyRequired[0],
                     _participantsOnlyRequired[1],
@@ -595,7 +599,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.IsValidParticipantList(new List<ParticipantsForCommand> {
                     _participantsOnlyRequired[0],
                     _participantsOnlyRequired[1],
@@ -615,7 +619,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var fr =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -648,7 +652,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
@@ -667,7 +671,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
@@ -686,7 +690,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Operation,
@@ -705,7 +709,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         {
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var fr = new ParticipantsForCommand(
                     Organization.Operation,
                     null,
@@ -728,7 +732,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var participantWithFunctionalRoleAndExternalEmail =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -748,7 +752,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var participantWithFunctionalRoleAndExternalEmail =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -768,7 +772,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var participantWithFunctionalRoleAndExternalEmail =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -788,7 +792,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -808,7 +812,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -828,7 +832,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.OnlyRequiredParticipantsHaveLowestSortKeys(_participantsOnlyRequired);
                 Assert.IsTrue(result);
             }
@@ -840,7 +844,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -859,7 +863,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = dut.OnlyRequiredParticipantsHaveLowestSortKeys(new List<ParticipantsForCommand> {
                     new ParticipantsForCommand(
                         Organization.Contractor,
@@ -884,7 +888,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -903,7 +907,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var externalPerson =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -922,7 +926,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -941,7 +945,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -960,7 +964,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -986,7 +990,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var externalPerson =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1005,7 +1009,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var person =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1024,7 +1028,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1043,7 +1047,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var functionalRole =
                     new ParticipantsForCommand(
                         Organization.Commissioning,
@@ -1070,7 +1074,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1082,7 +1086,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoExistsAsync(100, default);
                 Assert.IsFalse(result);
             }
@@ -1091,12 +1095,30 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
         [TestMethod]
         public async Task ValidAccepterParticipantExistsAsync_FunctionalRoleAsAccepter_ReturnsTrue()
         {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code 2"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
+
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task ValidAccepterParticipantExistsAsync_PersonNotInFunctionalRole_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                Assert.IsFalse(result);
             }
         }
 
@@ -1106,7 +1128,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1118,7 +1140,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidAccepterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1130,7 +1152,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoHasAccepterAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1142,21 +1164,88 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoHasAccepterAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
+        public async Task ParticipantExistsAsync_ParticipantExists_ReturnsTrue()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.ParticipantExistsAsync(_participantId1, _invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+        
+        [TestMethod]
+        public async Task ParticipantExistsAsync_ParticipantDoesNotExistOnInvitation_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.ParticipantExistsAsync(_participantId1, _invitationIdWithNotCurrentUserOidAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task BeSignedParticipantAsync_ParticipantIsSigned_ReturnsTrue()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.IsSignedParticipantAsync(_participantId2, _invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+        
+        [TestMethod]
+        public async Task BeSignedParticipantAsync_ParticipantIsNotSigned_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.IsSignedParticipantAsync(_operationCurrentPersonId, _invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+
+        [TestMethod]
         public async Task ValidCompleterParticipantExistsAsyncAsync_FunctionalRoleAsCompleter_ReturnsTrue()
         {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
+
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
                 Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task ValidCompleterParticipantExistsAsyncAsync_PersonNotInFunctionalRole_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithFrAsParticipants, default);
+                Assert.IsFalse(result);
             }
         }
 
@@ -1166,7 +1255,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1178,7 +1267,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidCompleterParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1190,7 +1279,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoHasCompleterAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1202,7 +1291,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoHasCompleterAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsFalse(result);
             }
@@ -1214,7 +1303,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithFrAsParticipants, _operationFrId, default);
                 Assert.IsTrue(result);
             }
@@ -1226,7 +1315,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
                 Assert.IsTrue(result);
             }
@@ -1238,7 +1327,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithNotCurrentUserOidAsParticipants, _operationNotCurrentPersonId, default);
                 Assert.IsFalse(result);
             }
@@ -1250,7 +1339,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
                     await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _contractorId, default)
                 );
@@ -1264,7 +1353,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _commissioningId, default);
                 Assert.IsTrue(result);
             }
@@ -1276,7 +1365,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _additionalContractorId, default);
                 Assert.IsTrue(result);
             }
@@ -1288,7 +1377,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
                     await dut.ValidSigningParticipantExistsAsync(_invitationIdWithValidAndNonValidSignerParticipants, _supplierId, default)
                 );
@@ -1302,7 +1391,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.SignerExistsAsync(_invitationIdWithCurrentUserOidAsParticipants, _operationCurrentPersonId, default);
                 Assert.IsTrue(result);
             }
@@ -1314,7 +1403,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.SignerExistsAsync(_invitationIdWithoutParticipants, _operationCurrentPersonId, default);
                 Assert.IsFalse(result);
             }
@@ -1326,7 +1415,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithoutParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1338,7 +1427,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithAnotherCreator, default);
                 Assert.IsFalse(result);
             }
@@ -1356,7 +1445,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithAnotherCreator, default);
                 Assert.IsTrue(result);
             }
@@ -1370,7 +1459,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.CurrentUserIsCreatorOrIsInContractorFunctionalRoleOfInvitationAsync(_invitationIdWithAnotherCreator, default);
                 Assert.IsFalse(result);
             }
@@ -1382,7 +1471,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithFrAsParticipants, IpoStatus.Planned, default);
                 Assert.IsTrue(result);
             }
@@ -1394,7 +1483,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithCurrentUserOidAsParticipants, IpoStatus.Accepted, default);
                 Assert.IsTrue(result);
             }
@@ -1406,7 +1495,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithCurrentUserOidAsParticipants, IpoStatus.Planned, default);
                 Assert.IsFalse(result);
             }
@@ -1418,7 +1507,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.IpoIsInStageAsync(_invitationIdWithCurrentUserOidAsParticipants, IpoStatus.Completed, default);
                 Assert.IsFalse(result);
             }
@@ -1430,7 +1519,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.SameUserUnAcceptingThatAcceptedAsync(_invitationIdWithCurrentUserOidAsParticipants, default);
                 Assert.IsTrue(result);
             }
@@ -1442,9 +1531,123 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.Validators
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider);
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
                 var result = await dut.SameUserUnAcceptingThatAcceptedAsync(_invitationIdWithNotCurrentUserOidAsParticipants, default);
                 //This is not a full test coverage, because we do not have a history event for this accepting. We get false because there are not history events in this validation. Cannot add history event that is created by a user other than current user
+                Assert.IsFalse(result);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_ParticipantIsCurrentUser_ReturnsTrue()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasPermissionToEditParticipantAsync(_operationCurrentPersonId, _invitationIdWithCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_UserIsIpoAdmin_ReturnsTrue()
+        {
+            var permissionCacheMock = new Mock<IPermissionCache>();
+            IList<string> ipoAdminPrivilege = new List<string> { "IPO/ADMIN" };
+            permissionCacheMock
+                .Setup(x => x.GetPermissionsForUserAsync(_plantProvider.Plant, _currentUserOid))
+                .Returns(Task.FromResult(ipoAdminPrivilege));
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, permissionCacheMock.Object);
+                var result = await dut.HasPermissionToEditParticipantAsync(_operationNotCurrentPersonId, _invitationIdWithNotCurrentUserOidAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_UserIsNotIpoAdmin_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasPermissionToEditParticipantAsync(_operationNotCurrentPersonId, _invitationIdWithNotCurrentUserOidAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_UserIsFirstContractor_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasPermissionToEditParticipantAsync(_contractorFrId, _invitationIdWithFrAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_UserIsFirstConstructionCompany_ReturnsTrue()
+        {
+            _personApiServiceMock.Setup(i => i.GetPersonInFunctionalRoleAsync(
+                    TestPlant,
+                    _currentUserOid.ToString(),
+                    "FR code 2"))
+                .Returns(Task.FromResult(new ForeignApi.ProCoSysPerson() { AzureOid = _currentUserOid.ToString() }));
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasPermissionToEditParticipantAsync(_constructionCompanyFrId, _invitationIdWithFrAsParticipants, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasPermissionToEditParticipantAsync_UserIsNotInContractorFr_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasPermissionToEditParticipantAsync(_contractorFrId, _invitationIdWithFrAsParticipants, default);
+                Assert.IsFalse(result);
+            }
+        }
+        
+        [TestMethod]
+        public async Task HasOppositeAttendedStatusAsync_ParticipantHasOppositeAttendedStatus_ReturnsTrue()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasOppositeAttendedStatusAsync(_contractorFrId, _invitationIdWithFrAsParticipants, true, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasOppositeAttendedStatusAsync_ParticipantDoesNotHaveOppositeAttendedStatus_ReturnsFalse()
+        {
+            using (var context =
+                   new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new InvitationValidator(context, _currentUserProvider, _personApiService, _plantProvider, _permissionCache);
+                var result = await dut.HasOppositeAttendedStatusAsync(_contractorFrId, _invitationIdWithFrAsParticipants, false, default);
                 Assert.IsFalse(result);
             }
         }

--- a/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
@@ -821,6 +821,49 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
         }
         #endregion
 
+        #region UpdateAttendedStatus
+        [TestMethod]
+        public void UpdateAttendedStatus_ShouldNotUpdateAttendedStatus_WhenIpoIsCanceled()
+            => Assert.ThrowsException<Exception>(()
+                => _dutWithCanceledStatus.UpdateAttendedStatus(
+                    _functionalRoleParticipant,
+                    true,
+                    _functionalRoleParticipant.RowVersion.ConvertToString()));
+
+        [TestMethod]
+        public void UpdateAttendedStatus_ShouldUpdateAttendedStatusEvent()
+        {
+            _dutDpIpo.UpdateAttendedStatus(
+                _personParticipant,
+                true,
+                _personParticipant.RowVersion.ConvertToString());
+
+            Assert.IsInstanceOfType(_dutDpIpo.PreSaveDomainEvents.Last(), typeof(AttendedStatusUpdatedEvent));
+        }
+        #endregion
+
+
+        #region UpdateNote
+        [TestMethod]
+        public void UpdateNote_ShouldNotUpdateNote_WhenIpoIsCanceled()
+            => Assert.ThrowsException<Exception>(()
+                => _dutWithCanceledStatus.UpdateNote(
+                    _functionalRoleParticipant,
+                    "note",
+                    _functionalRoleParticipant.RowVersion.ConvertToString()));
+
+        [TestMethod]
+        public void UpdateNote_ShouldUpdateNoteEvent()
+        {
+            _dutDpIpo.UpdateNote(
+                _personParticipant,
+                "note",
+                _personParticipant.RowVersion.ConvertToString());
+
+            Assert.IsInstanceOfType(_dutDpIpo.PreSaveDomainEvents.Last(), typeof(NoteUpdatedEvent));
+        }
+        #endregion
+
         #region Complete
         [TestMethod]
         public void CompleteIpo_ShouldNotCompleteIpo_WhenIpoIsNotPlanned()

--- a/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Domain.Tests/AggregateModels/InvitationAggregate/InvitationTests.cs
@@ -831,7 +831,7 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
                     _functionalRoleParticipant.RowVersion.ConvertToString()));
 
         [TestMethod]
-        public void UpdateAttendedStatus_ShouldUpdateAttendedStatusEvent()
+        public void UpdateAttendedStatus_ShouldAddUpdateAttendedStatusEvent()
         {
             _dutDpIpo.UpdateAttendedStatus(
                 _personParticipant,
@@ -839,6 +839,17 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
                 _personParticipant.RowVersion.ConvertToString());
 
             Assert.IsInstanceOfType(_dutDpIpo.PreSaveDomainEvents.Last(), typeof(AttendedStatusUpdatedEvent));
+        }
+
+        [TestMethod]
+        public void UpdateAttendedStatus_ShouldUpdateAttendedStatus()
+        {
+            _dutDpIpo.UpdateAttendedStatus(
+                _personParticipant,
+                true,
+                _personParticipant.RowVersion.ConvertToString());
+
+            Assert.IsTrue(_dutDpIpo.Participants.First().Attended);
         }
         #endregion
 
@@ -853,7 +864,7 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
                     _functionalRoleParticipant.RowVersion.ConvertToString()));
 
         [TestMethod]
-        public void UpdateNote_ShouldUpdateNoteEvent()
+        public void UpdateNote_ShouldAddUpdateNoteEvent()
         {
             _dutDpIpo.UpdateNote(
                 _personParticipant,
@@ -861,6 +872,17 @@ namespace Equinor.ProCoSys.IPO.Domain.Tests.AggregateModels.InvitationAggregate
                 _personParticipant.RowVersion.ConvertToString());
 
             Assert.IsInstanceOfType(_dutDpIpo.PreSaveDomainEvents.Last(), typeof(NoteUpdatedEvent));
+        }
+
+        [TestMethod]
+        public void UpdateNote_ShouldUpdateNote()
+        {
+            _dutDpIpo.UpdateNote(
+                _personParticipant,
+                "note",
+                _personParticipant.RowVersion.ConvertToString());
+
+            Assert.AreEqual("note", _dutDpIpo.Participants.First().Note);
         }
         #endregion
 

--- a/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
@@ -24,6 +24,7 @@ namespace Equinor.ProCoSys.IPO.Test.Common
         protected Mock<IPlantProvider> _plantProviderMock;
         protected IPlantProvider _plantProvider;
         protected ICurrentUserProvider _currentUserProvider;
+        protected IPermissionCache _permissionCache;
         protected Mock<IPersonApiService> _personApiServiceMock;
         protected IPersonApiService _personApiService;
         protected IEventDispatcher _eventDispatcher;
@@ -45,6 +46,9 @@ namespace Equinor.ProCoSys.IPO.Test.Common
 
             var eventDispatcher = new Mock<IEventDispatcher>();
             _eventDispatcher = eventDispatcher.Object;
+
+            var permissionCacheMock = new Mock<IPermissionCache>();
+            _permissionCache = permissionCacheMock.Object;
 
             _timeProvider = new ManualTimeProvider(new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc));
             TimeService.SetProvider(_timeProvider);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerNegativeTests.cs
@@ -1150,10 +1150,112 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         }
         #endregion
 
-        #region ChangeAttendedStatusOnParticipants
+        #region UpdateAttendedStatusOnParticipant
+        [TestMethod]
+        public async Task ChangeAttendedStatus_AsAnonymous_ShouldReturnUnauthorized()
+            => await InvitationsControllerTestsHelper.UpdateAttendedStatusOnParticipantAsync(
+                UserType.Anonymous,
+                TestFactory.PlantWithAccess,
+                9999,
+                new ParticipantToUpdateAttendedStatusDto(),
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task ChangeAttendedStatus_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await InvitationsControllerTestsHelper.UpdateAttendedStatusOnParticipantAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                9999,
+                new ParticipantToUpdateAttendedStatusDto(),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task ChangeAttendedStatus_AsPlanner_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await InvitationsControllerTestsHelper.UpdateAttendedStatusOnParticipantAsync(
+                UserType.Planner,
+                TestFactory.UnknownPlant,
+                9999,
+                new ParticipantToUpdateAttendedStatusDto(),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task ChangeAttendedStatus_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await InvitationsControllerTestsHelper.UpdateAttendedStatusOnParticipantAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithAccess,
+                9999,
+                new ParticipantToUpdateAttendedStatusDto(),
+                HttpStatusCode.Forbidden);
+
+
+        [TestMethod]
+        public async Task ChangeAttendedStatus_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.UpdateAttendedStatusOnParticipantAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                123456,
+                new ParticipantToUpdateAttendedStatusDto(),
+                HttpStatusCode.BadRequest,
+                "Invitation with this ID does not exist");
+        #endregion
+
+        #region UpdateNoteOnParticipant
+        [TestMethod]
+        public async Task ChangeNote_AsAnonymous_ShouldReturnUnauthorized()
+            => await InvitationsControllerTestsHelper.UpdateNoteOnParticipantAsync(
+                UserType.Anonymous,
+                TestFactory.PlantWithAccess,
+                9999,
+                new ParticipantToUpdateNoteDto(),
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task ChangeNote_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await InvitationsControllerTestsHelper.UpdateNoteOnParticipantAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                9999,
+                new ParticipantToUpdateNoteDto(),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task ChangeNote_AsPlanner_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await InvitationsControllerTestsHelper.UpdateNoteOnParticipantAsync(
+                UserType.Planner,
+                TestFactory.UnknownPlant,
+                9999,
+                new ParticipantToUpdateNoteDto(),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task ChangeNote_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await InvitationsControllerTestsHelper.UpdateNoteOnParticipantAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithAccess,
+                9999,
+                new ParticipantToUpdateNoteDto(),
+                HttpStatusCode.Forbidden);
+
+
+        [TestMethod]
+        public async Task ChangeNote_AsPlanner_ShouldReturnBadRequest_WhenUnknownInvitationId()
+            => await InvitationsControllerTestsHelper.UpdateNoteOnParticipantAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                123456,
+                new ParticipantToUpdateNoteDto(),
+                HttpStatusCode.BadRequest,
+                "Invitation with this ID does not exist");
+        #endregion
+
+        #region ChangeAttendedStatusAndNotesOnParticipants
         [TestMethod]
         public async Task ChangeAttendedStatusOnParticipants_AsAnonymous_ShouldReturnUnauthorized()
-            => await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            => await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                 UserType.Anonymous,
                 TestFactory.PlantWithoutAccess,
                 9999,
@@ -1162,7 +1264,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
         [TestMethod]
         public async Task ChangeAttendedStatusOnParticipants_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
-            => await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            => await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
                 9999,
@@ -1172,7 +1274,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
         [TestMethod]
         public async Task ChangeAttendedStatusOnParticipants_AsPlanner_ShouldReturnBadRequest_WhenUnknownPlant()
-            => await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            => await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                 UserType.Planner,
                 TestFactory.UnknownPlant,
                 9999,
@@ -1182,7 +1284,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
         [TestMethod]
         public async Task ChangeAttendedStatusOnParticipants_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
-            => await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            => await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                 UserType.Hacker,
                 TestFactory.PlantWithAccess,
                 9999,
@@ -1196,7 +1298,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             var (_, participantToChangeDtos) = await CreateValidParticipantToChangeDtosAsync(_participantsForSigning);
 
             // Act
-            await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                            UserType.Signer,
                            TestFactory.PlantWithAccess,
                            9999,
@@ -1213,7 +1315,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             participantToChangeDtos[0].Id = 290690;
 
             // Act
-            await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                            UserType.Signer,
                            TestFactory.PlantWithAccess,
                            invitationToChangeId,
@@ -1230,7 +1332,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             participantToChangeDtos[0].RowVersion = TestFactory.WrongButValidRowVersion;
 
             // Act
-            await InvitationsControllerTestsHelper.ChangeAttendedStatusOnParticipantsAsync(
+            await InvitationsControllerTestsHelper.ChangeAttendedStatusAndNotesOnParticipantsAsync(
                            UserType.Signer,
                            TestFactory.PlantWithAccess,
                            invitationToChangeId,

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -38,10 +38,16 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
         protected TestProfile _sigurdSigner;
         protected TestProfile _contractor;
         protected TestProfile _pernillaPlanner;
+        protected TestProfile _andreaAdmin;
 
         [TestInitialize]
         public async Task TestInitializeAsync()
         {
+            _sigurdSigner = TestFactory.Instance.GetTestUserForUserType(UserType.Signer).Profile;
+            _pernillaPlanner = TestFactory.Instance.GetTestUserForUserType(UserType.Planner).Profile;
+            _contractor = TestFactory.Instance.GetTestUserForUserType(UserType.Contractor).Profile;
+            _andreaAdmin = TestFactory.Instance.GetTestUserForUserType(UserType.Admin).Profile;
+
             var personParticipant = new CreateInvitedPersonDto
             {
                 AzureOid = Guid.NewGuid(),
@@ -50,7 +56,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             };
             var person1InFunctionalRoleParticipant = new CreateInvitedPersonDto
             {
-                AzureOid = Guid.NewGuid(),
+                AzureOid = new Guid(_contractor.Oid),
                 Email = "per@test.com"
             };
             var person2InFunctionalRoleParticipant = new CreateInvitedPersonDto
@@ -63,14 +69,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                 Code = FunctionalRoleCode,
                 Persons = new List<CreateInvitedPersonDto>
                 {
-                    person1InFunctionalRoleParticipant, 
+                    person1InFunctionalRoleParticipant,
                     person2InFunctionalRoleParticipant
                 }
             };
-            
-            _sigurdSigner = TestFactory.Instance.GetTestUserForUserType(UserType.Signer).Profile;
-            _pernillaPlanner = TestFactory.Instance.GetTestUserForUserType(UserType.Planner).Profile;
-            _contractor = TestFactory.Instance.GetTestUserForUserType(UserType.Contractor).Profile;
 
             _participants = new List<CreateParticipantsDto>
             {
@@ -256,6 +258,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
                     "IPO",
                     It.IsAny<List<string>>()))
                 .Returns(Task.FromResult(_pernillaPlanner.AsProCoSysPerson()));
+
+            TestFactory.Instance
+                .PersonApiServiceMock
+                .Setup(x => x.GetPersonByOidWithPrivilegesAsync(
+                    TestFactory.PlantWithAccess,
+                    _andreaAdmin.Oid,
+                    "IPO",
+                    It.IsAny<List<string>>()))
+                .Returns(Task.FromResult(_andreaAdmin.AsProCoSysPerson()));
 
             TestFactory.Instance
                 .PersonApiServiceMock

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsHelper.cs
@@ -376,7 +376,39 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
             return await response.Content.ReadAsStringAsync();
         }
 
-        public static async Task ChangeAttendedStatusOnParticipantsAsync(
+        public static async Task UpdateAttendedStatusOnParticipantAsync(
+            UserType userType,
+            string plant,
+            int id,
+            ParticipantToUpdateAttendedStatusDto dto,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var serializePayload = JsonConvert.SerializeObject(dto);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant)
+                .PutAsync($"{Route}/{id}/AttendedStatus", content);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+        
+        public static async Task UpdateNoteOnParticipantAsync(
+            UserType userType,
+            string plant,
+            int id,
+            ParticipantToUpdateNoteDto dto,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var serializePayload = JsonConvert.SerializeObject(dto);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant)
+                .PutAsync($"{Route}/{id}/Note", content);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+        
+        public static async Task ChangeAttendedStatusAndNotesOnParticipantsAsync(
             UserType userType,
             string plant,
             int id,

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/ParticipantToUpdateAttendedStatusDto.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/ParticipantToUpdateAttendedStatusDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
+{
+    public class ParticipantToUpdateAttendedStatusDto
+    {
+        public int Id { get; set; }
+        public bool Attended { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -41,6 +41,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
         private const string CreatorOid = "00000000-0000-0000-0000-000000000004";
         private const string HackerOid = "00000000-0000-0000-0000-000000000666";
         private const string ContractorOid = "00000000-0000-0000-0000-000000000007";
+        private const string AdminOid = "00000000-0000-0000-0000-000000000008";
 
         private const string IntegrationTestEnvironment = "IntegrationTests";
         private readonly string _connectionString;
@@ -307,7 +308,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
 
             AddContractorUser(commonProCoSysPlants, commonProCoSysProjects);
 
-            AddCreatorUser(commonProCoSysPlants, commonProCoSysProjects); 
+            AddCreatorUser(commonProCoSysPlants, commonProCoSysProjects);
+
+            AddAdminUser(commonProCoSysPlants, commonProCoSysProjects);
 
             var webHostBuilder = WithWebHostBuilder(builder =>
             {
@@ -467,6 +470,42 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
                         Permissions.IPO_READ,
                         Permissions.IPO_WRITE,
                         Permissions.IPO_VOIDUNVOID,
+                    },
+                    ProCoSysProjects = commonProCoSysProjects
+                });
+
+        // Authenticated user with all IPO permissions
+        private void AddAdminUser(
+            List<ProCoSysPlant> commonProCoSysPlants,
+            List<ProCoSysProject> commonProCoSysProjects)
+            => _testUsers.Add(UserType.Admin,
+                new TestUser
+                {
+                    Profile =
+                        new TestProfile
+                        {
+                            FirstName = "Andrea",
+                            LastName = "Admin",
+                            UserName = "AndreaAdminUserName",
+                            Oid = AdminOid,
+                            Email = "andrea.admin@pcs.pcs"
+                        },
+                    ProCoSysPlants = commonProCoSysPlants,
+                    ProCoSysPermissions = new List<string>
+                    {
+                        Permissions.COMMPKG_READ,
+                        Permissions.MCPKG_READ,
+                        Permissions.PROJECT_READ,
+                        Permissions.LIBRARY_FUNCTIONAL_ROLE_READ,
+                        Permissions.USER_READ,
+                        Permissions.IPO_READ,
+                        Permissions.IPO_WRITE,
+                        Permissions.IPO_CREATE,
+                        Permissions.IPO_DELETE,
+                        Permissions.IPO_ATTACHFILE,
+                        Permissions.IPO_DETACHFILE,
+                        Permissions.IPO_VOIDUNVOID,
+                        Permissions.IPO_ADMIN,
                     },
                     ProCoSysProjects = commonProCoSysProjects
                 });

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/UserType.cs
@@ -8,6 +8,7 @@
         Viewer,
         Hacker,
         Contractor,
-        Creator
+        Creator,
+        Admin
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Authorizations/AccessValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Authorizations/AccessValidatorTests.cs
@@ -12,6 +12,8 @@ using Equinor.ProCoSys.IPO.Command.InvitationCommands.SignPunchOut;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnSignPunchOut;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusOnParticipant;
+using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateNoteOnParticipant;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UploadAttachment;
 using Equinor.ProCoSys.IPO.Command.PersonCommands.CreateSavedFilter;
 using Equinor.ProCoSys.IPO.Domain;
@@ -512,6 +514,77 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         }
         #endregion
 
+        #region UpdateAttendedStatusCommand
+        [TestMethod]
+        public async Task ValidateAsync_OnUpdateAttendedStatusOnParticipantCommand_ShouldReturnTrue_WhenAccessToProject()
+        {
+            // Arrange
+            var command = new UpdateAttendedStatusOnParticipantCommand(
+                _invitationIdWithAccessToProject,
+                0,
+                true,
+                null);
+
+            // act
+            var result = await _dut.ValidateAsync(command);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task ValidateAsync_OnUpdateAttendedStatusOnParticipantCommand_ShouldReturnFalse_WhenNoAccessToProject()
+        {
+            // Arrange
+            var command = new UpdateAttendedStatusOnParticipantCommand(
+                _invitationIdWithoutAccessToProject,
+                0,
+                true,
+                null);
+
+            // act
+            var result = await _dut.ValidateAsync(command);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+        #endregion
+
+        #region UpdateNoteCommand
+        [TestMethod]
+        public async Task ValidateAsync_OnUpdateNoteOnParticipantCommand_ShouldReturnTrue_WhenAccessToProject()
+        {
+            // Arrange
+            var command = new UpdateNoteOnParticipantCommand(
+                _invitationIdWithAccessToProject,
+                0,
+                null,
+                null);
+
+            // act
+            var result = await _dut.ValidateAsync(command);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task ValidateAsync_OnUpdateNoteOnParticipantCommand_ShouldReturnFalse_WhenNoAccessToProject()
+        {
+            // Arrange
+            var command = new UpdateNoteOnParticipantCommand(
+                _invitationIdWithoutAccessToProject,
+                0,
+                null,
+                null);
+
+            // act
+            var result = await _dut.ValidateAsync(command);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+        #endregion
         #region CreateSavedFilterCommand
         [TestMethod]
         public async Task ValidateAsync_OnCreateSavedFilterCommand_ShouldReturnTrue_WhenAccessToProject()


### PR DESCRIPTION
Add endpoints to edit note and attended status on participants where IPO is not cancelled.

Following can edit:
- Users with IPO/ADMIN privilege
- The participant himself can edit his own info
- First contractor
- First construction company

To use endpoints the user must have either IPO/WRITE, IPO/SIGN, or IPO/ADMIN privilege.

Some changes in validation for some commands -> do validation of person in functional role in commandValidator instead of commandHandler. This was a conscious choice in the beginning of the project, but doesnt seem like there is a reason for why it shouldnt be done in the commandValidator any more.

-Small change in uncomplete/unaccept -> if FR, all persons in FR can unsign

[AB#89474](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89474)