### PR TITLE
90646 - Upgrade Fusion.Integration to latest version

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
-    <PackageReference Include="Fusion.Integration" Version="5.4.3" />
+    <PackageReference Include="Fusion.Integration" Version="5.5.4" />
     <PackageReference Include="Fusion.Integration.Meeting" Version="5.3.1" />
     <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />


### PR DESCRIPTION
Fusion has fixed a config issue on their end, and it should be safe to update this package now.

Have tested in test that initial nuget upgrading build works in test, so this is just a reversal of my last PR that downgraded Fusion.Integration.

AB#906464