### PR TITLE
92505 - Add scope across system - renaming fix

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -376,10 +376,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 throw new IpoValidationException("Could not find all mc pkgs in scope.");
             }
 
-            var initialCommPkg = mcPkgDetailsList.FirstOrDefault();
-            if (initialCommPkg != null)
+            var initialMcPkg = mcPkgDetailsList.FirstOrDefault();
+            if (initialMcPkg != null)
             {
-                var initialSection = initialCommPkg.Section;
+                var initialSection = initialMcPkg.Section;
                 if (mcPkgDetailsList.Any(commPkg => commPkg.Section != initialSection))
                 {
                     throw new IpoValidationException("Mc pkg scope must be within a section.");

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -347,6 +347,16 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 throw new IpoValidationException("Could not find all comm pkgs in scope.");
             }
 
+            var initialCommPkg = commPkgDetailsList.FirstOrDefault();
+            if (initialCommPkg != null)
+            {
+                var initialSection = initialCommPkg.Section;
+                if (commPkgDetailsList.Any(commPkg => commPkg.Section != initialSection))
+                {
+                    throw new IpoValidationException("Comm pkg scope must be within a section.");
+                }
+            }
+
             return commPkgDetailsList.Select(c => new CommPkg(
                 _plantProvider.Plant,
                 projectName,
@@ -364,6 +374,16 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             if (mcPkgDetailsList.Count != mcPkgScope.Count)
             {
                 throw new IpoValidationException("Could not find all mc pkgs in scope.");
+            }
+
+            var initialCommPkg = mcPkgDetailsList.FirstOrDefault();
+            if (initialCommPkg != null)
+            {
+                var initialSection = initialCommPkg.Section;
+                if (mcPkgDetailsList.Any(commPkg => commPkg.Section != initialSection))
+                {
+                    throw new IpoValidationException("Mc pkg scope must be within a section.");
+                }
             }
 
             return mcPkgDetailsList.Select(mc => new McPkg(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -363,7 +363,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 c.CommPkgNo,
                 c.Description,
                 c.CommStatus,
-                c.SystemPath)).ToList();
+                c.System)).ToList();
         }
 
         private async Task<List<McPkg>> GetMcPkgsToAddAsync(IList<string> mcPkgScope, string projectName)
@@ -392,7 +392,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                     mc.CommPkgNo,
                     mc.McPkgNo,
                     mc.Description,
-                    mc.SystemPath)).ToList();
+                    mc.System)).ToList();
         }
 
         private async Task<Guid> CreateOutlookMeeting(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -347,15 +347,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 throw new IpoValidationException("Could not find all comm pkgs in scope.");
             }
 
-            var initialCommPkg = commPkgDetailsList.FirstOrDefault();
-            if (initialCommPkg != null)
-            {
-                var initialSystem = initialCommPkg.SystemSubString;
-                if (commPkgDetailsList.Any(commPkg => commPkg.SystemSubString != initialSystem))
-                {
-                    throw new IpoValidationException("Comm pkg scope must be within a system.");
-                }
-            }
             return commPkgDetailsList.Select(c => new CommPkg(
                 _plantProvider.Plant,
                 projectName,
@@ -373,16 +364,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
             if (mcPkgDetailsList.Count != mcPkgScope.Count)
             {
                 throw new IpoValidationException("Could not find all mc pkgs in scope.");
-            }
-
-            var initialMcPkg = mcPkgDetailsList.FirstOrDefault();
-            if (initialMcPkg != null)
-            {
-                var initialSystem = initialMcPkg.SystemSubString;
-                if (mcPkgDetailsList.Any(mcPkg => mcPkg.SystemSubString != initialSystem))
-                {
-                    throw new IpoValidationException("Mc pkg scope must be within a system.");
-                }
             }
 
             return mcPkgDetailsList.Select(mc => new McPkg(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -363,7 +363,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                 c.CommPkgNo,
                 c.Description,
                 c.CommStatus,
-                c.System)).ToList();
+                c.SystemPath)).ToList();
         }
 
         private async Task<List<McPkg>> GetMcPkgsToAddAsync(IList<string> mcPkgScope, string projectName)
@@ -392,7 +392,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
                     mc.CommPkgNo,
                     mc.McPkgNo,
                     mc.Description,
-                    mc.System)).ToList();
+                    mc.SystemPath)).ToList();
         }
 
         private async Task<Guid> CreateOutlookMeeting(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -115,16 +115,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     throw new IpoValidationException("Could not find all mc pkgs in scope.");
                 }
 
-                var initialMcPkg = mcPkgsFromMain.FirstOrDefault();
-                if (initialMcPkg != null)
-                {
-                    var initialSystem = initialMcPkg.SystemSubString;
-                    if (mcPkgsFromMain.Any(mcPkg => mcPkg.SystemSubString != initialSystem))
-                    {
-                        throw new IpoValidationException("Mc pkg scope must be within a system.");
-                    }
-                }
-
                 return mcPkgsFromMain.Select(mc => new McPkg(
                     _plantProvider.Plant,
                     projectName,
@@ -147,17 +137,6 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                 if (commPkgsFromMain.Count != commPkgNos.Count)
                 {
                     throw new IpoValidationException("Could not find all comm pkgs in scope.");
-                }
-
-                var initialCommPkg = commPkgsFromMain.FirstOrDefault();
-                if (initialCommPkg != null)
-                {
-                    var initialSystem = initialCommPkg.SystemSubString;
-
-                    if (commPkgsFromMain.Any(commPkg => commPkg.SystemSubString != initialSystem))
-                    {
-                        throw new IpoValidationException("Comm pkg scope must be within a system.");
-                    }
                 }
 
                 return commPkgsFromMain.Select(c => new CommPkg(

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -131,7 +131,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     mc.CommPkgNo,
                     mc.McPkgNo,
                     mc.Description,
-                    mc.System)).ToList();
+                    mc.SystemPath)).ToList();
             }
 
             return new List<McPkg>();
@@ -165,7 +165,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     c.CommPkgNo,
                     c.Description,
                     c.CommStatus,
-                    c.System)).ToList();
+                    c.SystemPath)).ToList();
             }
 
             return new List<CommPkg>();

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -115,10 +115,10 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     throw new IpoValidationException("Could not find all mc pkgs in scope.");
                 }
 
-                var initialCommPkg = mcPkgsFromMain.FirstOrDefault();
-                if (initialCommPkg != null)
+                var initialMcPkg = mcPkgsFromMain.FirstOrDefault();
+                if (initialMcPkg != null)
                 {
-                    var initialSection = initialCommPkg.Section;
+                    var initialSection = initialMcPkg.Section;
                     if (mcPkgsFromMain.Any(commPkg => commPkg.Section != initialSection))
                     {
                         throw new IpoValidationException("Mc pkg scope must be within a section.");

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -131,7 +131,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     mc.CommPkgNo,
                     mc.McPkgNo,
                     mc.Description,
-                    mc.SystemPath)).ToList();
+                    mc.System)).ToList();
             }
 
             return new List<McPkg>();
@@ -165,7 +165,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     c.CommPkgNo,
                     c.Description,
                     c.CommStatus,
-                    c.SystemPath)).ToList();
+                    c.System)).ToList();
             }
 
             return new List<CommPkg>();

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandHandler.cs
@@ -115,6 +115,16 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                     throw new IpoValidationException("Could not find all mc pkgs in scope.");
                 }
 
+                var initialCommPkg = mcPkgsFromMain.FirstOrDefault();
+                if (initialCommPkg != null)
+                {
+                    var initialSection = initialCommPkg.Section;
+                    if (mcPkgsFromMain.Any(commPkg => commPkg.Section != initialSection))
+                    {
+                        throw new IpoValidationException("Mc pkg scope must be within a section.");
+                    }
+                }
+
                 return mcPkgsFromMain.Select(mc => new McPkg(
                     _plantProvider.Plant,
                     projectName,
@@ -137,6 +147,16 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
                 if (commPkgsFromMain.Count != commPkgNos.Count)
                 {
                     throw new IpoValidationException("Could not find all comm pkgs in scope.");
+                }
+
+                var initialCommPkg = commPkgsFromMain.FirstOrDefault();
+                if (initialCommPkg != null)
+                {
+                    var initialSection = initialCommPkg.Section;
+                    if (commPkgsFromMain.Any(commPkg => commPkg.Section != initialSection))
+                    {
+                        throw new IpoValidationException("Comm pkg scope must be within a section.");
+                    }
                 }
 
                 return commPkgsFromMain.Select(c => new CommPkg(

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
@@ -1,4 +1,6 @@
-﻿namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg
+﻿using System.Linq;
+
+namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg
 {
     public class ProCoSysCommPkg
     {
@@ -7,5 +9,9 @@
         public string Description { get; set; }
         public string CommStatus { get; set; }
         public string System { get; set; }
+        public string Section
+            => System.Count(s => s == '|') == 2
+                ? System.Substring(0, System.IndexOf('|'))
+                : null;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
@@ -7,6 +7,5 @@
         public string Description { get; set; }
         public string CommStatus { get; set; }
         public string System { get; set; }
-        public string SystemSubString => System.Substring(0, System.LastIndexOf('|'));
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
@@ -8,10 +8,10 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg
         public string CommPkgNo { get; set; }
         public string Description { get; set; }
         public string CommStatus { get; set; }
-        public string SystemPath { get; set; }
+        public string System { get; set; }
         public string Section
-            => SystemPath.Count(s => s == '|') == 2
-                ? SystemPath.Substring(0, SystemPath.IndexOf('|'))
+            => System.Count(s => s == '|') == 2
+                ? System.Substring(0, System.IndexOf('|'))
                 : null;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/CommPkg/ProCoSysCommPkg.cs
@@ -8,10 +8,10 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.CommPkg
         public string CommPkgNo { get; set; }
         public string Description { get; set; }
         public string CommStatus { get; set; }
-        public string System { get; set; }
+        public string SystemPath { get; set; }
         public string Section
-            => System.Count(s => s == '|') == 2
-                ? System.Substring(0, System.IndexOf('|'))
+            => SystemPath.Count(s => s == '|') == 2
+                ? SystemPath.Substring(0, SystemPath.IndexOf('|'))
                 : null;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
@@ -9,10 +9,10 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg
         public string Description { get; set; }
         public string DisciplineCode { get; set; }
         public string CommPkgNo { get; set; }
-        public string System { get; set; }
+        public string SystemPath { get; set; }
         public string Section
-            => System.Count(s => s == '|') == 2
-                ? System.Substring(0, System.IndexOf('|'))
+            => SystemPath.Count(s => s == '|') == 2
+                ? SystemPath.Substring(0, SystemPath.IndexOf('|'))
                 : null;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
@@ -9,10 +9,10 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg
         public string Description { get; set; }
         public string DisciplineCode { get; set; }
         public string CommPkgNo { get; set; }
-        public string SystemPath { get; set; }
+        public string System { get; set; }
         public string Section
-            => SystemPath.Count(s => s == '|') == 2
-                ? SystemPath.Substring(0, SystemPath.IndexOf('|'))
+            => System.Count(s => s == '|') == 2
+                ? System.Substring(0, System.IndexOf('|'))
                 : null;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
@@ -8,6 +8,5 @@
         public string DisciplineCode { get; set; }
         public string CommPkgNo { get; set; }
         public string System { get; set; }
-        public string SystemSubString => System.Substring(0, System.LastIndexOf('|'));
     }
 }

--- a/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
+++ b/src/Equinor.ProCoSys.IPO.MainApi/MainApi/McPkg/ProCoSysMcPkg.cs
@@ -1,4 +1,6 @@
-﻿namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg
+﻿using System.Linq;
+
+namespace Equinor.ProCoSys.IPO.ForeignApi.MainApi.McPkg
 {
     public class ProCoSysMcPkg
     {
@@ -8,5 +10,9 @@
         public string DisciplineCode { get; set; }
         public string CommPkgNo { get; set; }
         public string System { get; set; }
+        public string Section
+            => System.Count(s => s == '|') == 2
+                ? System.Substring(0, System.IndexOf('|'))
+                : null;
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandler.cs
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetCommPkgsInProject
                         commPkg.CommPkgNo,
                         commPkg.Description,
                         commPkg.CommStatus,
-                        commPkg.SystemPath)).ToList();
+                        commPkg.System)).ToList();
             }
 
             var commPkgSearchDto = new ProCoSysCommPkgSearchDto(mainApiCommPkgSearchResult.MaxAvailable, commPkgDtos);

--- a/src/Equinor.ProCoSys.IPO.Query/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetCommPkgsInProject/GetCommPkgsInProjectQueryHandler.cs
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetCommPkgsInProject
                         commPkg.CommPkgNo,
                         commPkg.Description,
                         commPkg.CommStatus,
-                        commPkg.System)).ToList();
+                        commPkg.SystemPath)).ToList();
             }
 
             var commPkgSearchDto = new ProCoSysCommPkgSearchDto(mainApiCommPkgSearchResult.MaxAvailable, commPkgDtos);

--- a/src/Equinor.ProCoSys.IPO.Query/GetMcPkgsUnderCommPkgInProject/GetMcPkgsUnderCommPkgInProjectQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetMcPkgsUnderCommPkgInProject/GetMcPkgsUnderCommPkgInProjectQueryHandler.cs
@@ -38,7 +38,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetMcPkgsUnderCommPkgInProject
                     mcPkg.Description,
                     mcPkg.DisciplineCode,
                     mcPkg.CommPkgNo,
-                    mcPkg.System)).ToList();
+                    mcPkg.SystemPath)).ToList();
 
             return new SuccessResult<List<ProCoSysMcPkgDto>>(mcPkgDtos);
         }

--- a/src/Equinor.ProCoSys.IPO.Query/GetMcPkgsUnderCommPkgInProject/GetMcPkgsUnderCommPkgInProjectQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetMcPkgsUnderCommPkgInProject/GetMcPkgsUnderCommPkgInProjectQueryHandler.cs
@@ -38,7 +38,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetMcPkgsUnderCommPkgInProject
                     mcPkg.Description,
                     mcPkg.DisciplineCode,
                     mcPkg.CommPkgNo,
-                    mcPkg.SystemPath)).ToList();
+                    mcPkg.System)).ToList();
 
             return new SuccessResult<List<ProCoSysMcPkgDto>>(mcPkgDtos);
         }

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -46,8 +46,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         private const string _mcPkgNo2 = "MC2";
         private const string _commPkgNo = "Comm1";
         private const string _commPkgNo2 = "Comm2";
-        private const string _system = "1|2";
-        private const string _system2 = "2|2";
+        private const string _system = "13|1|2";
+        private const string _system2 = "12|1|2";
         private static Guid _azureOid = new Guid("11111111-1111-2222-2222-333333333333");
 
         private readonly string _plant = "PCS$TEST_PLANT";
@@ -259,6 +259,34 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         }
 
         [TestMethod]
+        public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSection()
+        {
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system2 };
+            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
+
+            _mcPkgApiServiceMock
+                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, _mcPkgScope))
+                .Returns(Task.FromResult(mcPkgDetails));
+
+            var command = new CreateInvitationCommand(
+                _title,
+                _description,
+                _location,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _projectName,
+                _type,
+                _participants,
+                _mcPkgScope,
+                null);
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Mc pkg scope must be within a section"));
+        }
+
+        [TestMethod]
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfMcScopeIsNotFoundInMain()
         {
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { _mcPkgDetails1 };
@@ -282,6 +310,39 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
             Assert.IsTrue(result.Message.StartsWith("Could not find all mc pkgs in scope"));
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSections()
+        {
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _system2 };
+            IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
+            var commPkgScope = new List<string>
+            {
+                _commPkgNo,
+                _commPkgNo2
+            };
+
+            _commPkgApiServiceMock
+                .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, commPkgScope))
+                .Returns(Task.FromResult(commPkgDetails));
+
+            var command = new CreateInvitationCommand(
+                _title,
+                _description,
+                _location,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _projectName,
+                _type,
+                _participants,
+                null,
+                commPkgScope);
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Comm pkg scope must be within a section"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -145,8 +145,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
 
             _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
 
-            _mcPkgDetails1 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
-            _mcPkgDetails2 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection };
+            _mcPkgDetails1 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithoutSection };
+            _mcPkgDetails2 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithoutSection };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg>{ _mcPkgDetails1, _mcPkgDetails2 };
 
             _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
@@ -252,8 +252,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         [TestMethod]
         public async Task HandleCreateInvitationCommand_ShouldBeAbleToAddMcScopeAcrossSystems()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection2 };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithoutSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithoutSection2 };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
 
             _mcPkgApiServiceMock
@@ -281,8 +281,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         [TestMethod]
         public async Task HandleCreateInvitationCommand_ShouldBeAbleToAddCommScopeAcrossSystems()
         {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithoutSection };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithoutSection2 };
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _systemPathWithoutSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _systemPathWithoutSection2 };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
             var commPkgScope = new List<string>
             {
@@ -326,8 +326,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         [TestMethod]
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSection()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithSection };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithSection2 };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithSection2 };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
 
             _mcPkgApiServiceMock
@@ -380,8 +380,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         [TestMethod]
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSections()
         {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithSection2 };
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _systemPathWithSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _systemPathWithSection2 };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
             var commPkgScope = new List<string>
             {
@@ -414,7 +414,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsNotFoundInMain()
         {
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { 
-                    new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection }
+                    new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _systemPathWithSection }
                 };
 
             var commPkgScope = new List<string>

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -46,8 +46,10 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         private const string _mcPkgNo2 = "MC2";
         private const string _commPkgNo = "Comm1";
         private const string _commPkgNo2 = "Comm2";
-        private const string _system = "13|1|2";
-        private const string _system2 = "12|1|2";
+        private const string _systemPathWithoutSection = "1|2";
+        private const string _systemPathWithoutSection2 = "2|2";
+        private const string _systemPathWithSection = "13|1|2";
+        private const string _systemPathWithSection2 = "12|1|2";
         private static Guid _azureOid = new Guid("11111111-1111-2222-2222-333333333333");
 
         private readonly string _plant = "PCS$TEST_PLANT";
@@ -143,8 +145,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
 
             _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
 
-            _mcPkgDetails1 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system};
-            _mcPkgDetails2 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system};
+            _mcPkgDetails1 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
+            _mcPkgDetails2 = new ProCoSysMcPkg {CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg>{ _mcPkgDetails1, _mcPkgDetails2 };
 
             _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
@@ -248,6 +250,69 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         }
 
         [TestMethod]
+        public async Task HandleCreateInvitationCommand_ShouldBeAbleToAddMcScopeAcrossSystems()
+        {
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection2 };
+            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
+
+            _mcPkgApiServiceMock
+                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, _mcPkgScope))
+                .Returns(Task.FromResult(mcPkgDetails));
+
+            var command = new CreateInvitationCommand(
+                _title,
+                _description,
+                _location,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _projectName,
+                _type,
+                _participants,
+                _mcPkgScope,
+                null);
+
+            await _dut.Handle(command, default);
+
+            Assert.IsNotNull(_createdInvitation);
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public async Task HandleCreateInvitationCommand_ShouldBeAbleToAddCommScopeAcrossSystems()
+        {
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithoutSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithoutSection2 };
+            IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
+            var commPkgScope = new List<string>
+            {
+                _commPkgNo,
+                _commPkgNo2
+            };
+
+            _commPkgApiServiceMock
+                .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, commPkgScope))
+                .Returns(Task.FromResult(commPkgDetails));
+
+            var command = new CreateInvitationCommand(
+                _title,
+                _description,
+                _location,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _projectName,
+                DisciplineType.MDP,
+                _participants,
+                null,
+                commPkgScope);
+
+            await _dut.Handle(command, default);
+
+            Assert.IsNotNull(_createdInvitation);
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
         public async Task HandleCreateInvitationCommand_ShouldAddMcPkgsToInvitation()
         {
             await _dut.Handle(_command, default);
@@ -261,8 +326,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         [TestMethod]
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSection()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system2 };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithSection2 };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
 
             _mcPkgApiServiceMock
@@ -315,8 +380,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         [TestMethod]
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSections()
         {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _system2 };
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithSection2 };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
             var commPkgScope = new List<string>
             {
@@ -349,7 +414,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsNotFoundInMain()
         {
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { 
-                    new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system }
+                    new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection }
                 };
 
             var commPkgScope = new List<string>

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CreateInvitation/CreateInvitationCommandHandlerTests.cs
@@ -259,34 +259,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
         }
 
         [TestMethod]
-        public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSystems()
-        {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system2 };
-            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
-
-            _mcPkgApiServiceMock
-                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, _mcPkgScope))
-                .Returns(Task.FromResult(mcPkgDetails));
-
-            var command = new CreateInvitationCommand(
-                _title,
-                _description,
-                _location,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _projectName,
-                _type,
-                _participants,
-                _mcPkgScope,
-                null);
-
-            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
-            Assert.IsTrue(result.Message.StartsWith("Mc pkg scope must be within a system"));
-        }
-
-        [TestMethod]
         public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfMcScopeIsNotFoundInMain()
         {
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { _mcPkgDetails1 };
@@ -310,39 +282,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CreateInvitation
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
             Assert.IsTrue(result.Message.StartsWith("Could not find all mc pkgs in scope"));
-        }
-
-        [TestMethod]
-        public async Task HandlingCreateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSystems()
-        {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _system2 };
-            IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
-            var commPkgScope = new List<string>
-            {
-                _commPkgNo,
-                _commPkgNo2
-            };
-
-            _commPkgApiServiceMock
-                .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, commPkgScope))
-                .Returns(Task.FromResult(commPkgDetails));
-
-            var command = new CreateInvitationCommand(
-                _title,
-                _description,
-                _location,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _projectName,
-                _type,
-                _participants,
-                null,
-                commPkgScope);
-
-            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
-            Assert.IsTrue(result.Message.StartsWith("Comm pkg scope must be within a system"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -380,42 +380,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         }
 
         [TestMethod]
-        public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSystems()
-        {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system };
-            var mcPkgDetails3 = new ProCoSysMcPkg { CommPkgNo = "CommPkgNo3", Description = "D2", Id = 2, McPkgNo = _mcPkgNo3, System = _system2 };
-            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2, mcPkgDetails3 };
-            var addedScope = new List<string>
-            {
-                _mcPkgNo1,
-                _mcPkgNo2,
-                _mcPkgNo3
-            };
-
-            _mcPkgApiServiceMock
-                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, addedScope))
-                .Returns(Task.FromResult(mcPkgDetails));
-
-            var command = new EditInvitationCommand(
-                _dpInvitationId,
-                _newTitle,
-                _newDescription,
-                null,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _typeDp,
-                _updatedParticipants,
-                addedScope,
-                null,
-                _rowVersion);
-
-            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
-            Assert.IsTrue(result.Message.StartsWith("Mc pkg scope must be within a system"));
-        }
-
-        [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsOnMDP()
         {
             var command = new EditInvitationCommand(
@@ -574,40 +538,6 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
             Assert.IsTrue(result.Message.StartsWith("Could not find all mc pkgs in scope"));
-        }
-
-        [TestMethod]
-        public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSystems()
-        {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _system2 };
-            IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
-            var newScope = new List<string>
-            {
-                _commPkgNo,
-                _commPkgNo2
-            };
-
-            _commPkgApiServiceMock
-                .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, newScope))
-                .Returns(Task.FromResult(commPkgDetails));
-
-            var command = new EditInvitationCommand(
-                _dpInvitationId,
-                _newTitle,
-                _newDescription,
-                null,
-                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
-                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _typeDp,
-                _updatedParticipants,
-                null,
-                newScope,
-                _rowVersion);
-
-            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
-                _dut.Handle(command, default));
-            Assert.IsTrue(result.Message.StartsWith("Comm pkg scope must be within a system"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -68,8 +68,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private const string _mcPkgNo3 = "MC3";
         private const string _commPkgNo = "Comm1";
         private const string _commPkgNo2 = "Comm2";
-        private const string _system = "1|2";
-        private const string _system2 = "2|2";
+        private const string _system = "14|1|2";
+        private const string _system2 = "15|1|2";
 
         private readonly List<ParticipantsForEditCommand> _updatedParticipants = new List<ParticipantsForEditCommand>
         {
@@ -380,6 +380,42 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         }
 
         [TestMethod]
+        public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSections()
+        {
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system };
+            var mcPkgDetails3 = new ProCoSysMcPkg { CommPkgNo = "CommPkgNo3", Description = "D2", Id = 2, McPkgNo = _mcPkgNo3, System = _system2 };
+            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2, mcPkgDetails3 };
+            var addedScope = new List<string>
+            {
+                _mcPkgNo1,
+                _mcPkgNo2,
+                _mcPkgNo3
+            };
+
+            _mcPkgApiServiceMock
+                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, addedScope))
+                .Returns(Task.FromResult(mcPkgDetails));
+
+            var command = new EditInvitationCommand(
+                _dpInvitationId,
+                _newTitle,
+                _newDescription,
+                null,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _typeDp,
+                _updatedParticipants,
+                addedScope,
+                null,
+                _rowVersion);
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Mc pkg scope must be within a section"));
+        }
+
+        [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsOnMDP()
         {
             var command = new EditInvitationCommand(
@@ -538,6 +574,40 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
                 _dut.Handle(command, default));
             Assert.IsTrue(result.Message.StartsWith("Could not find all mc pkgs in scope"));
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSections()
+        {
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _system2 };
+            IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
+            var newScope = new List<string>
+            {
+                _commPkgNo,
+                _commPkgNo2
+            };
+
+            _commPkgApiServiceMock
+                .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, newScope))
+                .Returns(Task.FromResult(commPkgDetails));
+
+            var command = new EditInvitationCommand(
+                _dpInvitationId,
+                _newTitle,
+                _newDescription,
+                null,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _typeDp,
+                _updatedParticipants,
+                null,
+                newScope,
+                _rowVersion);
+
+            var result = await Assert.ThrowsExceptionAsync<IpoValidationException>(() =>
+                _dut.Handle(command, default));
+            Assert.IsTrue(result.Message.StartsWith("Comm pkg scope must be within a section"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -141,7 +141,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             _unitOfWorkMock = new Mock<IUnitOfWork>();
 
             //mock comm pkg response from main API
-            var commPkgDetails = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, CommStatus = "OK", SystemPath = _systemPathWithSection};
+            var commPkgDetails = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, CommStatus = "OK", System = _systemPathWithSection};
             IList<ProCoSysCommPkg> pcsCommPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails };
             _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
             _commPkgApiServiceMock
@@ -149,8 +149,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 .Returns(Task.FromResult(pcsCommPkgDetails));
 
             //mock mc pkg response from main API
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithoutSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithoutSection };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
             _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
             _mcPkgApiServiceMock
@@ -384,8 +384,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandleEditInvitationCommand_ShouldBeAbleToAddMcScopeAcrossSystems()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection2 };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithoutSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithoutSection2 };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
             var mcPkgScope = new List<string>
             {
@@ -418,8 +418,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandleEditInvitationCommand_ShouldBeAbleToAddCommScopeAcrossSystems()
         {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithoutSection };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithoutSection2 };
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _systemPathWithoutSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _systemPathWithoutSection2 };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
             var commPkgScope = new List<string>
             {
@@ -453,9 +453,9 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSections()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithSection };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithSection };
-            var mcPkgDetails3 = new ProCoSysMcPkg { CommPkgNo = "CommPkgNo3", Description = "D2", Id = 2, McPkgNo = _mcPkgNo3, SystemPath = _systemPathWithSection2 };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithSection };
+            var mcPkgDetails3 = new ProCoSysMcPkg { CommPkgNo = "CommPkgNo3", Description = "D2", Id = 2, McPkgNo = _mcPkgNo3, System = _systemPathWithSection2 };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2, mcPkgDetails3 };
             var addedScope = new List<string>
             {
@@ -615,8 +615,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsNotFoundInMain()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithSection };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithSection };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _systemPathWithSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _systemPathWithSection };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
             var addedScope = new List<string>
             {
@@ -650,8 +650,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSections()
         {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithSection2 };
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _systemPathWithSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _systemPathWithSection2 };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
             var newScope = new List<string>
             {
@@ -684,7 +684,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsNotFoundInMain()
         {
-            var commPkg = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection };
+            var commPkg = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _systemPathWithSection };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkg };
             var newScope = new List<string>
             {

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/EditInvitation/EditInvitationCommandHandlerTests.cs
@@ -68,8 +68,10 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         private const string _mcPkgNo3 = "MC3";
         private const string _commPkgNo = "Comm1";
         private const string _commPkgNo2 = "Comm2";
-        private const string _system = "14|1|2";
-        private const string _system2 = "15|1|2";
+        private const string _systemPathWithoutSection = "1|2";
+        private const string _systemPathWithoutSection2 = "2|2";
+        private const string _systemPathWithSection = "14|1|2";
+        private const string _systemPathWithSection2 = "15|1|2";
 
         private readonly List<ParticipantsForEditCommand> _updatedParticipants = new List<ParticipantsForEditCommand>
         {
@@ -139,7 +141,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
             _unitOfWorkMock = new Mock<IUnitOfWork>();
 
             //mock comm pkg response from main API
-            var commPkgDetails = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, CommStatus = "OK", System = _system};
+            var commPkgDetails = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, CommStatus = "OK", SystemPath = _systemPathWithSection};
             IList<ProCoSysCommPkg> pcsCommPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails };
             _commPkgApiServiceMock = new Mock<ICommPkgApiService>();
             _commPkgApiServiceMock
@@ -147,8 +149,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
                 .Returns(Task.FromResult(pcsCommPkgDetails));
 
             //mock mc pkg response from main API
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system};
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system};
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
             _mcPkgApiServiceMock = new Mock<IMcPkgApiService>();
             _mcPkgApiServiceMock
@@ -239,8 +241,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             var mcPkgs = new List<McPkg>
             {
-                new McPkg(_plant, _projectName, _commPkgNo, _mcPkgNo1, "d", _system),
-                new McPkg(_plant, _projectName, _commPkgNo, _mcPkgNo2, "d2", _system)
+                new McPkg(_plant, _projectName, _commPkgNo, _mcPkgNo1, "d", _systemPathWithSection),
+                new McPkg(_plant, _projectName, _commPkgNo, _mcPkgNo2, "d2", _systemPathWithSection)
             };
             //create invitation
             _dpInvitation = new Invitation(
@@ -258,8 +260,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
 
             var commPkgs = new List<CommPkg>
             {
-                new CommPkg(_plant, _projectName, _commPkgNo, "d", "ok", _system),
-                new CommPkg(_plant, _projectName, _commPkgNo, "d2", "ok", _system)
+                new CommPkg(_plant, _projectName, _commPkgNo, "d", "ok", _systemPathWithSection),
+                new CommPkg(_plant, _projectName, _commPkgNo, "d2", "ok", _systemPathWithSection)
             };
             //create invitation
             _mdpInvitation = new Invitation(
@@ -380,11 +382,80 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         }
 
         [TestMethod]
+        public async Task HandleEditInvitationCommand_ShouldBeAbleToAddMcScopeAcrossSystems()
+        {
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithoutSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithoutSection2 };
+            IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
+            var mcPkgScope = new List<string>
+            {
+                _mcPkgNo1,
+                _mcPkgNo2
+            };
+
+            _mcPkgApiServiceMock
+                .Setup(x => x.GetMcPkgsByMcPkgNosAsync(_plant, _projectName, _mcPkgScope))
+                .Returns(Task.FromResult(mcPkgDetails));
+
+            var command = new EditInvitationCommand(
+                _dpInvitationId,
+                _newTitle,
+                _newDescription,
+                null,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _typeDp,
+                _updatedParticipants,
+                mcPkgScope,
+                null,
+                _rowVersion);
+
+            await _dut.Handle(command, default);
+
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandleEditInvitationCommand_ShouldBeAbleToAddCommScopeAcrossSystems()
+        {
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithoutSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithoutSection2 };
+            IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
+            var commPkgScope = new List<string>
+            {
+                _commPkgNo,
+                _commPkgNo2
+            };
+
+            _commPkgApiServiceMock
+                .Setup(x => x.GetCommPkgsByCommPkgNosAsync(_plant, _projectName, commPkgScope))
+                .Returns(Task.FromResult(commPkgDetails));
+
+            var command = new EditInvitationCommand(
+                _dpInvitationId,
+                _newTitle,
+                _newDescription,
+                null,
+                new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
+                new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
+                _typeMdp,
+                _updatedParticipants,
+                null,
+                commPkgScope,
+                _rowVersion);
+
+            await _dut.Handle(command, default);
+
+            _unitOfWorkMock.Verify(t => t.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+
+        [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsAcrossSections()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system };
-            var mcPkgDetails3 = new ProCoSysMcPkg { CommPkgNo = "CommPkgNo3", Description = "D2", Id = 2, McPkgNo = _mcPkgNo3, System = _system2 };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithSection };
+            var mcPkgDetails3 = new ProCoSysMcPkg { CommPkgNo = "CommPkgNo3", Description = "D2", Id = 2, McPkgNo = _mcPkgNo3, SystemPath = _systemPathWithSection2 };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2, mcPkgDetails3 };
             var addedScope = new List<string>
             {
@@ -544,8 +615,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfMcScopeIsNotFoundInMain()
         {
-            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, System = _system };
-            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, System = _system };
+            var mcPkgDetails1 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, McPkgNo = _mcPkgNo1, SystemPath = _systemPathWithSection };
+            var mcPkgDetails2 = new ProCoSysMcPkg { CommPkgNo = _commPkgNo, Description = "D2", Id = 2, McPkgNo = _mcPkgNo2, SystemPath = _systemPathWithSection };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> { mcPkgDetails1, mcPkgDetails2 };
             var addedScope = new List<string>
             {
@@ -579,8 +650,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsAcrossSections()
         {
-            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
-            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, System = _system2 };
+            var commPkgDetails1 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection };
+            var commPkgDetails2 = new ProCoSysCommPkg { CommPkgNo = _commPkgNo2, Description = "D2", Id = 2, SystemPath = _systemPathWithSection2 };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkgDetails1, commPkgDetails2 };
             var newScope = new List<string>
             {
@@ -613,7 +684,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.EditInvitation
         [TestMethod]
         public async Task HandlingUpdateIpoCommand_ShouldThrowErrorIfCommPkgScopeIsNotFoundInMain()
         {
-            var commPkg = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, System = _system };
+            var commPkg = new ProCoSysCommPkg { CommPkgNo = _commPkgNo, Description = "D1", Id = 1, SystemPath = _systemPathWithSection };
             IList<ProCoSysCommPkg> commPkgDetails = new List<ProCoSysCommPkg> { commPkg };
             var newScope = new List<string>
             {

--- a/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/CommPkg/MainApiCommPkgServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/CommPkg/MainApiCommPkgServiceTests.cs
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
                                 CommPkgNo = "CommNo1",
                                 Description = "Description1",
                                 CommStatus = "OK",
-                                System = "1|2"
+                                SystemPath = "1|2"
                             },
                             new ProCoSysCommPkg
                             {
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
                                 CommPkgNo = "CommNo2",
                                 Description = "Description2",
                                 CommStatus = "PA",
-                                System = "1|2"
+                                SystemPath = "1|2"
                             },
                             new ProCoSysCommPkg
                             {
@@ -59,7 +59,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
                                 CommPkgNo = "CommNo3",
                                 Description = "Description3",
                                 CommStatus = "PB",
-                                System = "1|2"
+                                SystemPath = "1|2"
                             }
                         }
             };
@@ -163,7 +163,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
             Assert.AreEqual("CommNo1", commPkg.CommPkgNo);
             Assert.AreEqual("Description1", commPkg.Description);
             Assert.AreEqual("OK", commPkg.CommStatus);
-            Assert.AreEqual("1|2", commPkg.System);
+            Assert.AreEqual("1|2", commPkg.SystemPath);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/CommPkg/MainApiCommPkgServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/CommPkg/MainApiCommPkgServiceTests.cs
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
                                 CommPkgNo = "CommNo1",
                                 Description = "Description1",
                                 CommStatus = "OK",
-                                SystemPath = "1|2"
+                                System = "1|2"
                             },
                             new ProCoSysCommPkg
                             {
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
                                 CommPkgNo = "CommNo2",
                                 Description = "Description2",
                                 CommStatus = "PA",
-                                SystemPath = "1|2"
+                                System = "1|2"
                             },
                             new ProCoSysCommPkg
                             {
@@ -59,7 +59,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
                                 CommPkgNo = "CommNo3",
                                 Description = "Description3",
                                 CommStatus = "PB",
-                                SystemPath = "1|2"
+                                System = "1|2"
                             }
                         }
             };
@@ -163,7 +163,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.CommPkg
             Assert.AreEqual("CommNo1", commPkg.CommPkgNo);
             Assert.AreEqual("Description1", commPkg.Description);
             Assert.AreEqual("OK", commPkg.CommStatus);
-            Assert.AreEqual("1|2", commPkg.SystemPath);
+            Assert.AreEqual("1|2", commPkg.System);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/McPkg/MainApiMcPkgServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/McPkg/MainApiMcPkgServiceTests.cs
@@ -39,7 +39,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
                 McPkgNo = "McNo1",
                 Description = "Description1",
                 DisciplineCode = "A",
-                SystemPath = "1|2"
+                System = "1|2"
             };
             _proCoSysMcPkg2 = new ProCoSysMcPkg
             {
@@ -47,7 +47,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
                 McPkgNo = "McNo2",
                 Description = "Description2",
                 DisciplineCode = "A",
-                SystemPath = "1|2"
+                System = "1|2"
             };
             _proCoSysMcPkg3 = new ProCoSysMcPkg
             {
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
                 McPkgNo = "McNo3",
                 Description = "Description3",
                 DisciplineCode = "B",
-                SystemPath = "1|2"
+                System = "1|2"
             };
 
             _foreignApiClient
@@ -103,7 +103,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
             Assert.AreEqual("McNo1", mcPkg.McPkgNo);
             Assert.AreEqual("Description1", mcPkg.Description);
             Assert.AreEqual("A", mcPkg.DisciplineCode);
-            Assert.AreEqual("1|2", mcPkg.SystemPath);
+            Assert.AreEqual("1|2", mcPkg.System);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
             Assert.AreEqual("McNo1", mcPkg.McPkgNo);
             Assert.AreEqual("Description1", mcPkg.Description);
             Assert.AreEqual("A", mcPkg.DisciplineCode);
-            Assert.AreEqual("1|2", mcPkg.SystemPath);
+            Assert.AreEqual("1|2", mcPkg.System);
             mcPkg = result[1];
             Assert.AreEqual(222222222, mcPkg.Id);
             Assert.AreEqual("McNo2", mcPkg.McPkgNo);

--- a/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/McPkg/MainApiMcPkgServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.MainApi.Tests/MainApi/McPkg/MainApiMcPkgServiceTests.cs
@@ -39,7 +39,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
                 McPkgNo = "McNo1",
                 Description = "Description1",
                 DisciplineCode = "A",
-                System = "1|2"
+                SystemPath = "1|2"
             };
             _proCoSysMcPkg2 = new ProCoSysMcPkg
             {
@@ -47,7 +47,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
                 McPkgNo = "McNo2",
                 Description = "Description2",
                 DisciplineCode = "A",
-                System = "1|2"
+                SystemPath = "1|2"
             };
             _proCoSysMcPkg3 = new ProCoSysMcPkg
             {
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
                 McPkgNo = "McNo3",
                 Description = "Description3",
                 DisciplineCode = "B",
-                System = "1|2"
+                SystemPath = "1|2"
             };
 
             _foreignApiClient
@@ -103,7 +103,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
             Assert.AreEqual("McNo1", mcPkg.McPkgNo);
             Assert.AreEqual("Description1", mcPkg.Description);
             Assert.AreEqual("A", mcPkg.DisciplineCode);
-            Assert.AreEqual("1|2", mcPkg.System);
+            Assert.AreEqual("1|2", mcPkg.SystemPath);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace Equinor.ProCoSys.IPO.ForeignApi.Tests.MainApi.McPkg
             Assert.AreEqual("McNo1", mcPkg.McPkgNo);
             Assert.AreEqual("Description1", mcPkg.Description);
             Assert.AreEqual("A", mcPkg.DisciplineCode);
-            Assert.AreEqual("1|2", mcPkg.System);
+            Assert.AreEqual("1|2", mcPkg.SystemPath);
             mcPkg = result[1];
             Assert.AreEqual(222222222, mcPkg.Id);
             Assert.AreEqual("McNo2", mcPkg.McPkgNo);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -160,11 +160,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             _mcPkgDetails1 = new ProCoSysMcPkg
             {
-                CommPkgNo = KnownTestData.CommPkgNo, Description = "D1", Id = 1, McPkgNo = McPkgNo1, SystemPath = KnownTestData.System
+                CommPkgNo = KnownTestData.CommPkgNo, Description = "D1", Id = 1, McPkgNo = McPkgNo1, System = KnownTestData.System
             };
             _mcPkgDetails2 = new ProCoSysMcPkg
             {
-                CommPkgNo = KnownTestData.CommPkgNo, Description = "D2", Id = 2, McPkgNo = McPkgNo2, SystemPath = KnownTestData.System
+                CommPkgNo = KnownTestData.CommPkgNo, Description = "D2", Id = 2, McPkgNo = McPkgNo2, System = KnownTestData.System
             };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> {_mcPkgDetails1, _mcPkgDetails2};
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Invitations/InvitationsControllerTestsBase.cs
@@ -160,11 +160,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Invitations
 
             _mcPkgDetails1 = new ProCoSysMcPkg
             {
-                CommPkgNo = KnownTestData.CommPkgNo, Description = "D1", Id = 1, McPkgNo = McPkgNo1, System = KnownTestData.System
+                CommPkgNo = KnownTestData.CommPkgNo, Description = "D1", Id = 1, McPkgNo = McPkgNo1, SystemPath = KnownTestData.System
             };
             _mcPkgDetails2 = new ProCoSysMcPkg
             {
-                CommPkgNo = KnownTestData.CommPkgNo, Description = "D2", Id = 2, McPkgNo = McPkgNo2, System = KnownTestData.System
+                CommPkgNo = KnownTestData.CommPkgNo, Description = "D2", Id = 2, McPkgNo = McPkgNo2, SystemPath = KnownTestData.System
             };
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> {_mcPkgDetails1, _mcPkgDetails2};
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTestsBase.cs
@@ -69,7 +69,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Me
                 Description = "D1",
                 Id = 1,
                 McPkgNo = McPkgNo,
-                System = KnownTestData.System
+                SystemPath = KnownTestData.System
             };
 
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> {_mcPkgDetails};

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Me/MeControllerTestsBase.cs
@@ -69,7 +69,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Me
                 Description = "D1",
                 Id = 1,
                 McPkgNo = McPkgNo,
-                SystemPath = KnownTestData.System
+                System = KnownTestData.System
             };
 
             IList<ProCoSysMcPkg> mcPkgDetails = new List<ProCoSysMcPkg> {_mcPkgDetails};

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Scope/ScopeControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Scope/ScopeControllerTestsBase.cs
@@ -32,7 +32,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     CommStatus = "OK",
                     Description = "CommPkg1Description",
                     Id = 1,
-                    SystemPath = System
+                    System = System
                 },
                 new ProCoSysCommPkg
                 {
@@ -40,7 +40,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     CommStatus = "OS",
                     Description = "CommPkg2Description",
                     Id = 2,
-                    SystemPath = System
+                    System = System
                 }
             };
 
@@ -61,7 +61,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     McPkgNo = McPkgNo1,
                     Description = "McPkg1Description",
                     DisciplineCode = "A",
-                    SystemPath = System
+                    System = System
                 },
                 new ProCoSysMcPkg
                 {
@@ -70,7 +70,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     McPkgNo = McPkgNo2,
                     Description = "McPkg2Description",
                     DisciplineCode = "B",
-                    SystemPath = System
+                    System = System
                 }
             };
 

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Scope/ScopeControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Scope/ScopeControllerTestsBase.cs
@@ -32,7 +32,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     CommStatus = "OK",
                     Description = "CommPkg1Description",
                     Id = 1,
-                    System = System
+                    SystemPath = System
                 },
                 new ProCoSysCommPkg
                 {
@@ -40,7 +40,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     CommStatus = "OS",
                     Description = "CommPkg2Description",
                     Id = 2,
-                    System = System
+                    SystemPath = System
                 }
             };
 
@@ -61,7 +61,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     McPkgNo = McPkgNo1,
                     Description = "McPkg1Description",
                     DisciplineCode = "A",
-                    System = System
+                    SystemPath = System
                 },
                 new ProCoSysMcPkg
                 {
@@ -70,7 +70,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Scope
                     McPkgNo = McPkgNo2,
                     Description = "McPkg2Description",
                     DisciplineCode = "B",
-                    System = System
+                    SystemPath = System
                 }
             };
 


### PR DESCRIPTION
Rename SystemPath back to System as this wording needs to be identical to the one in MainApi.

[AB#92505](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/92505)