### PR TITLE
Make projectname required for endpoints

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Query.GetInvitationsQueries;
 
@@ -7,6 +8,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 {
     public class FilterDto
     {
+        [Required]
         public string ProjectName { get; set; }
         public IEnumerable<IpoStatus> IpoStatuses { get; set; }
         public string FunctionalRoleCode { get; set; }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDto.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate;
 using Equinor.ProCoSys.IPO.Query.GetInvitationsQueries;
 

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDto.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDto.cs
@@ -8,7 +8,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 {
     public class FilterDto
     {
-        [Required]
         public string ProjectName { get; set; }
         public IEnumerable<IpoStatus> IpoStatuses { get; set; }
         public string FunctionalRoleCode { get; set; }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDtoValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDtoValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+
+namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
+{
+    public class FilterDtoValidator : AbstractValidator<FilterDto>
+    {
+        public FilterDtoValidator()
+        {
+            RuleFor(x => x)
+                .NotNull();
+
+            RuleFor(x => x.ProjectName)
+                .NotNull()
+                .NotEmpty();
+        }
+    }
+}


### PR DESCRIPTION
ProjectName is now a required property for /Invitations and /ExportInvitationsToExcel endpoins.

[AB#81893](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81893)