### PR TITLE
Pbi/94186 fetch ipos accross projects

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/Filter.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/Filter.cs
@@ -18,5 +18,6 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries
         public DateTime? PunchOutDateFromUtc { get; set; }
         public DateTime? PunchOutDateToUtc { get; set; }
         public IList<PunchOutDateFilterType> PunchOutDates { get; set; } = new List<PunchOutDateFilterType>();
+        public string ProjectName { get; set; }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitations/GetInvitationsQuery.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitations/GetInvitationsQuery.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Equinor.ProCoSys.IPO.Domain;
 using MediatR;
 using ServiceResult;
@@ -12,13 +14,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitations
         public const int DefaultPage = 0;
         public const int DefaultPagingSize = 20;
 
-        public GetInvitationsQuery(string projectName, Sorting sorting = null, Filter filter = null, Paging paging = null)
+        public GetInvitationsQuery(List<string> projectNames, Sorting sorting = null, Filter filter = null, Paging paging = null)
         {
-            if (string.IsNullOrEmpty(projectName))
-            {
-                throw new ArgumentNullException(nameof(projectName));
-            }
-            ProjectName = projectName;
+            ProjectName = projectNames.FirstOrDefault();
             Sorting = sorting ?? new Sorting(DefaultSortingDirection, DefaultSortingProperty);
             Filter = filter ?? new Filter();
             Paging = paging ?? new Paging(DefaultPage, DefaultPagingSize);

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitations/GetInvitationsQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitations/GetInvitationsQueryHandler.cs
@@ -15,19 +15,38 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitations
     public class GetInvitationsQueryHandler : GetInvitationsQueryBase, IRequestHandler<GetInvitationsQuery, Result<InvitationsResult>>
     {
         private readonly IReadOnlyContext _context;
+        private readonly IPermissionCache _permissionCache;
+        private readonly IPlantProvider _plantProvider;
+        private readonly ICurrentUserProvider _currentUserProvider;
 
         private readonly DateTime _utcNow;
 
         public GetInvitationsQueryHandler(
-            IReadOnlyContext context)
+            IReadOnlyContext context,
+            IPermissionCache permissionCache,
+            IPlantProvider plantProvider,
+            ICurrentUserProvider currentUserProvider)
         {
             _context = context;
             _utcNow = TimeService.UtcNow;
+            _permissionCache = permissionCache;
+            _plantProvider = plantProvider;
+            _currentUserProvider = currentUserProvider;
         }
 
         public async Task<Result<InvitationsResult>> Handle(GetInvitationsQuery request, CancellationToken cancellationToken)
         {
-            var invitationForQueryDtos = CreateQueryableWithFilter(_context, request.ProjectName, request.Filter, _utcNow);
+            var projectNames = new List<string>();
+            if (request.ProjectName == null)
+            {
+                projectNames = (List<string>)await _permissionCache.GetProjectsForUserAsync(_plantProvider.Plant, _currentUserProvider.GetCurrentUserOid());
+            }
+            else
+            {
+                projectNames.Add(request.ProjectName);
+            }
+
+            var invitationForQueryDtos = CreateQueryableWithFilter(_context, projectNames, request.Filter, _utcNow);
 
             // count before adding sorting/paging
             var maxAvailable = await invitationForQueryDtos.CountAsync(cancellationToken);

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQuery.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQuery.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Equinor.ProCoSys.IPO.Domain;
 using MediatR;
 using ServiceResult;
@@ -10,13 +12,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
         public const SortingDirection DefaultSortingDirection = SortingDirection.Asc;
         public const SortingProperty DefaultSortingProperty = SortingProperty.CreatedAtUtc;
 
-        public GetInvitationsForExportQuery(string projectName, Sorting sorting = null, Filter filter = null)
+        public GetInvitationsForExportQuery(List<string> projectNames, Sorting sorting = null, Filter filter = null)
         {
-            if (string.IsNullOrEmpty(projectName))
-            {
-                throw new ArgumentNullException(nameof(projectName));
-            }
-            ProjectName = projectName;
+            ProjectName = projectNames.FirstOrDefault();
             Sorting = sorting ?? new Sorting(DefaultSortingDirection, DefaultSortingProperty);
             Filter = filter ?? new Filter();
         }

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsQueryBase.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsQueryBase.cs
@@ -106,6 +106,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries
                         case SortingProperty.AcceptedAtUtc:
                             invitationForQueryDtos = invitationForQueryDtos.OrderBy(dto => dto.AcceptedAtUtc);
                             break;
+                        case SortingProperty.ProjectName:
+                            invitationForQueryDtos= invitationForQueryDtos.OrderBy(dto => dto.ProjectName);
+                            break;
                         default:
                             invitationForQueryDtos = invitationForQueryDtos.OrderBy(dto => dto.Id);
                             break;
@@ -135,6 +138,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries
                             break;
                         case SortingProperty.AcceptedAtUtc:
                             invitationForQueryDtos = invitationForQueryDtos.OrderByDescending(dto => dto.AcceptedAtUtc);
+                            break;
+                        case SortingProperty.ProjectName:
+                            invitationForQueryDtos = invitationForQueryDtos.OrderByDescending(dto => dto.ProjectName);
                             break;
                         default:
                             invitationForQueryDtos = invitationForQueryDtos.OrderByDescending(dto => dto.Id);

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsQueryBase.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsQueryBase.cs
@@ -11,7 +11,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries
 {
     public abstract class GetInvitationsQueryBase
     {
-        protected IQueryable<InvitationForQueryDto> CreateQueryableWithFilter(IReadOnlyContext context, string projectName, Filter filter, DateTime utcNow)
+        protected IQueryable<InvitationForQueryDto> CreateQueryableWithFilter(IReadOnlyContext context, List<string> projectNames, Filter filter, DateTime utcNow)
         {
             var startOfThisWeekUtc = DateTime.MinValue;
             var startOfNextWeekUtc = DateTime.MinValue;
@@ -26,7 +26,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries
             var ipoIdStartWith = GetIpoIdStartWith(filter.IpoIdStartsWith);
 
             var queryable = from invitation in context.QuerySet<Invitation>()
-                where invitation.ProjectName == projectName &&
+                where projectNames.Contains(invitation.ProjectName) &&
                       (!filter.PunchOutDates.Any() ||
                            (filter.PunchOutDates.Contains(PunchOutDateFilterType.Overdue) && invitation.StartTimeUtc < utcNow) ||
                            (filter.PunchOutDates.Contains(PunchOutDateFilterType.ThisWeek) &&

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/SortingProperty.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/SortingProperty.cs
@@ -11,6 +11,7 @@
         CompletedAtUtc,
         AcceptedAtUtc,
         ContractorRep,
-        ConstructionCompanyRep
+        ConstructionCompanyRep,
+        ProjectName
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Authorizations/AccessValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Authorizations/AccessValidator.cs
@@ -37,6 +37,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Authorizations
 
             var userOid = _currentUserProvider.GetCurrentUserOid();
             if (request is IProjectRequest projectRequest &&
+                projectRequest.ProjectName != null &&
                 !_projectAccessChecker.HasCurrentUserAccessToProject(projectRequest.ProjectName))
             {
                 _logger.LogWarning($"Current user {userOid} don't have access to project {projectRequest.ProjectName}");

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDtoValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/FilterDtoValidator.cs
@@ -8,10 +8,6 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
         {
             RuleFor(x => x)
                 .NotNull();
-
-            RuleFor(x => x.ProjectName)
-                .NotNull()
-                .NotEmpty();
         }
     }
 }

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
@@ -565,6 +565,11 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 
         private static void FillFilterFromDto(FilterDto source, Filter target)
         {
+            if (source.ProjectName != null)
+            { 
+                target.ProjectName = source.ProjectName;
+            }
+            
             if (source.PunchOutDates != null)
             {
                 target.PunchOutDates = source.PunchOutDates.ToList();

--- a/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Controllers/Invitation/InvitationsController.cs
@@ -354,7 +354,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
                 new UpdateNoteOnParticipantCommand(id, dto.Id, dto.Note, dto.RowVersion));
             return this.FromResult(result);
         }
-        
+
         // TODO: This endpoint will be replaced by the two above, and this this endpoint can be removed once frontend stops using it.
         [Authorize(Roles = Permissions.IPO_SIGN)]
         [HttpPut("{id}/AttendedStatusAndNotes")]
@@ -544,8 +544,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 
         private static GetInvitationsQuery CreateGetInvitationsQuery(FilterDto filter, SortingDto sorting, PagingDto paging)
         {
+            var projectNames = new List<string>();
+
+            if (filter.ProjectName != null)
+            {
+                projectNames.Add(filter.ProjectName);
+            }
+
             var query = new GetInvitationsQuery(
-                filter.ProjectName,
+                projectNames,
                 new Sorting(sorting.Direction, sorting.Property),
                 new Filter(),
                 new Paging(paging.Page, paging.Size)
@@ -621,8 +628,15 @@ namespace Equinor.ProCoSys.IPO.WebApi.Controllers.Invitation
 
         private static GetInvitationsForExportQuery CreateGetInvitationsForExportQuery(FilterDto filter, SortingDto sorting)
         {
+            var projectNames = new List<string>();
+
+            if (filter.ProjectName != null)
+            {
+                projectNames.Add(filter.ProjectName);
+            }
+
             var query = new GetInvitationsForExportQuery(
-                filter.ProjectName,
+                projectNames,
                 new Sorting(sorting.Direction, sorting.Property),
                 new Filter()
             );

--- a/src/Equinor.ProCoSys.IPO.WebApi/Excel/ExcelConverter.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Excel/ExcelConverter.cs
@@ -31,21 +31,22 @@ namespace Equinor.ProCoSys.IPO.WebApi.Excel
         public static class InvitationSheetColumns
         {
             public static int IpoNo = 1;
-            public static int Status = 2;
-            public static int Title = 3;
-            public static int Description = 4;
-            public static int Location = 5;
-            public static int Type = 6;
-            public static int StartTimeUtc = 7;
-            public static int EndTimeUtc = 8;
-            public static int McPkgs = 9;
-            public static int CommPkgs = 10;
-            public static int ContractorRep = 11;
-            public static int ConstructionCompanyRep = 12;
-            public static int CompletedAtUtc = 13;
-            public static int AcceptedAtUtc = 14;
-            public static int CreatedAtUtc = 15;
-            public static int CreatedBy = 16;
+            public static int ProjectName = 2;
+            public static int Status = 3;
+            public static int Title = 4;
+            public static int Description = 5;
+            public static int Location = 6;
+            public static int Type = 7;
+            public static int StartTimeUtc = 8;
+            public static int EndTimeUtc = 9;
+            public static int McPkgs = 10;
+            public static int CommPkgs = 11;
+            public static int ContractorRep = 12;
+            public static int ConstructionCompanyRep = 13;
+            public static int CompletedAtUtc = 14;
+            public static int AcceptedAtUtc = 15;
+            public static int CreatedAtUtc = 16;
+            public static int CreatedBy = 17;
             public static int Last = CreatedBy;
         }
 
@@ -205,6 +206,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Excel
             row.Style.Font.SetBold();
             row.Style.Font.SetFontSize(12);
             row.Cell(InvitationSheetColumns.IpoNo).Value = "Ipo no";
+            row.Cell(InvitationSheetColumns.ProjectName).Value = "Project name";
             row.Cell(InvitationSheetColumns.Status).Value = "Status";
             row.Cell(InvitationSheetColumns.Title).Value = "Title";
             row.Cell(InvitationSheetColumns.Description).Value = "Description";
@@ -226,6 +228,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Excel
                 row = sheet.Row(++rowIdx);
 
                 row.Cell(InvitationSheetColumns.IpoNo).SetValue(invitation.Id).SetDataType(XLDataType.Text);
+                row.Cell(InvitationSheetColumns.ProjectName).SetValue(invitation.ProjectName).SetDataType(XLDataType.Text);
                 row.Cell(InvitationSheetColumns.Status).SetValue(invitation.Status).SetDataType(XLDataType.Text);
                 row.Cell(InvitationSheetColumns.Title).SetValue(invitation.Title).SetDataType(XLDataType.Text);
                 row.Cell(InvitationSheetColumns.Description).SetValue(invitation.Description).SetDataType(XLDataType.Text);

--- a/src/Equinor.ProCoSys.IPO.WebApi/Misc/ProjectChecker.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Misc/ProjectChecker.cs
@@ -30,7 +30,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.Misc
             var plant = _plantProvider.Plant;
             var userOid = _currentUserProvider.GetCurrentUserOid();
 
-            if (request is IProjectRequest projectRequest && !await _permissionCache.IsAValidProjectAsync(plant, userOid, projectRequest.ProjectName))
+            if (request is IProjectRequest projectRequest &&
+                projectRequest.ProjectName != null
+                && !await _permissionCache.IsAValidProjectAsync(plant, userOid, projectRequest.ProjectName))
             {
                 throw new InValidProjectException($"Project '{projectRequest.ProjectName}' is not a valid project in '{plant}'");
             }

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitations/GetInvitationsQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitations/GetInvitationsQueryHandlerTests.cs
@@ -25,9 +25,9 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
         private string _functionalRoleCode2 = "FrCode2";
         private string _functionalRoleCode3 = "FrCode3";
         private readonly Guid _personGuid = new Guid("11111111-2222-2222-2222-333333333333");
-        private readonly Guid _frPersonGuid1 = new Guid("11111111-2222-2222-2222-333333333332"); 
-        private readonly Guid _frPersonGuid2 = new Guid("11111111-2222-2222-2222-333333333335"); 
-        private readonly Guid _frPersonGuid3 = new Guid("11111111-2222-2222-2222-333333333336"); 
+        private readonly Guid _frPersonGuid1 = new Guid("11111111-2222-2222-2222-333333333332");
+        private readonly Guid _frPersonGuid2 = new Guid("11111111-2222-2222-2222-333333333335");
+        private readonly Guid _frPersonGuid3 = new Guid("11111111-2222-2222-2222-333333333336");
         private string _frEmail1 = "FR1@email.com";
         private string _personEmail1 = "P1@email.com";
         private string _personEmail2 = "P2@email.com";
@@ -36,8 +36,8 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
         private string _frPersonEmail1 = "frp1@email.com";
         private string _frPersonEmail2 = "frp2@email.com";
         private string _frPersonEmail3 = "frp3@email.com";
-        const string _projectName = "Project1";
-        const string _projectName2 = "Project2";
+        private List<string> _projectName = new List<string> { "Project1" };
+        private List<string> _projectName2 = new List<string> { "Project2" };
         const string _title1 = "Title1";
         const string _title2 = "Title2";
         const string _commPkgNo = "CommPkgNo";
@@ -197,7 +197,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
 
                 var commPkg = new CommPkg(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _commPkgNo,
                     description,
                     "OK",
@@ -205,7 +205,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
 
                 var mcPkg1 = new McPkg(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _commPkgNo,
                     _mcPkgNo,
                     description,
@@ -213,7 +213,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
 
                 var mcPkg2 = new McPkg(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _commPkgNo2,
                     _mcPkgNo,
                     description,
@@ -223,7 +223,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
 
                 _invitation1 = new Invitation(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _title1,
                     "Description",
                     DisciplineType.DP,
@@ -245,7 +245,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
 
                 _invitation2 = new Invitation(
                     TestPlant,
-                    _projectName2,
+                    _projectName2.FirstOrDefault(),
                     _title1,
                     "Description",
                     DisciplineType.MDP,
@@ -263,14 +263,14 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
 
                 _invitation3 = new Invitation(
                     TestPlant,
-                    _projectName2,
+                    _projectName2.FirstOrDefault(),
                     _title2,
                     "Description",
                     DisciplineType.DP,
                     startTime3,
                     startTime3.AddHours(1),
                     null,
-                    new List<McPkg> {mcPkg2},
+                    new List<McPkg> { mcPkg2 },
                     null);
 
                 _invitation3.AddParticipant(contractorPersonParticipant1);
@@ -289,7 +289,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
 
@@ -304,7 +304,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
 
@@ -318,7 +318,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, null, new Paging(1, 1));
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
 
@@ -334,7 +334,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, null, new Paging(1, 50));
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(2, result.Data.MaxAvailable);
@@ -348,7 +348,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, new Sorting(SortingDirection.Asc, SortingProperty.PunchOutDateUtc));
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -363,7 +363,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, new Sorting(SortingDirection.Desc, SortingProperty.PunchOutDateUtc));
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -375,13 +375,13 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
         [TestMethod]
         public async Task Handler_ShouldFilterOnId()
         {
-            var filter = new Filter {IpoIdStartsWith = "IPO-2"};
+            var filter = new Filter { IpoIdStartsWith = "IPO-2" };
 
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -391,13 +391,13 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
         [TestMethod]
         public async Task Handler_ShouldFilterOnStatusAccepted()
         {
-            var filter = new Filter { IpoStatuses = new List<IpoStatus> {IpoStatus.Accepted} };
+            var filter = new Filter { IpoStatuses = new List<IpoStatus> { IpoStatus.Accepted } };
 
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -413,7 +413,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -429,7 +429,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -445,7 +445,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -461,7 +461,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -477,7 +477,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -493,7 +493,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -509,7 +509,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -525,7 +525,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -541,7 +541,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -558,7 +558,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -574,10 +574,10 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
-                AssertCount(result.Data,1);
+                AssertCount(result.Data, 1);
             }
         }
 
@@ -591,7 +591,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -606,7 +606,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -622,7 +622,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -638,7 +638,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -654,7 +654,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -670,7 +670,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -686,7 +686,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -702,7 +702,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, sorting);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation2.Id, result.Data.Invitations.First().Id);
@@ -720,7 +720,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, sorting);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation3.Id, result.Data.Invitations.First().Id);
@@ -738,7 +738,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, sorting);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation3.Id, result.Data.Invitations.First().Id);
@@ -756,7 +756,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName2, sorting);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation2.Id, result.Data.Invitations.First().Id);
@@ -771,7 +771,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
 
@@ -783,7 +783,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
                 Assert.IsTrue(invitationDto.ConstructionCompanyRep.StartsWith(firstConstructionCompanyRep.FirstName));
                 Assert.IsFalse(invitationDto.AdditionalConstructionCompanyReps
                     .Any(p => p.StartsWith(firstConstructionCompanyRep.FirstName)));
-                Assert.AreEqual(invitationDto.AdditionalConstructionCompanyReps.Count(), 
+                Assert.AreEqual(invitationDto.AdditionalConstructionCompanyReps.Count(),
                     invitation.Participants.Count(p => p.Organization == Organization.ConstructionCompany && p.SortKey != 1));
             }
         }
@@ -794,7 +794,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitations
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsQuery(_projectName);
-                var dut = new GetInvitationsQueryHandler(context);
+                var dut = new GetInvitationsQueryHandler(context, _permissionCache, _plantProvider, _currentUserProvider);
 
                 var result = await dut.Handle(query, default);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQueryHandlerTests.cs
@@ -39,8 +39,9 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
         private string _personEmail3 = "P3@email.com";
         private string _frPersonEmail1 = "frp1@email.com";
         private string _frPersonEmail2 = "frp2@email.com";
-        const string _projectName = "Project1";
-        const string _projectName2 = "Project2";
+        private List<string> _projectName = new List<string> { "Project1" };
+        private List<string> _projectName2 = new List<string> { "Project2" };
+
         const string _title1 = "Title1";
         const string _title2 = "Title2";
         const string _commPkgNo = "CommPkgNo";
@@ -165,7 +166,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
 
                 var commPkg = new CommPkg(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _commPkgNo,
                     description,
                     "OK",
@@ -173,7 +174,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
 
                 var mcPkg1 = new McPkg(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _commPkgNo,
                     _mcPkgNo,
                     description,
@@ -181,7 +182,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
 
                 var mcPkg2 = new McPkg(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _commPkgNo2,
                     _mcPkgNo,
                     description,
@@ -191,7 +192,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
 
                 _invitation1 = new Invitation(
                     TestPlant,
-                    _projectName,
+                    _projectName.FirstOrDefault(),
                     _title1,
                     "Description",
                     DisciplineType.DP,
@@ -210,7 +211,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
 
                 _invitation2 = new Invitation(
                     TestPlant,
-                    _projectName2,
+                    _projectName2.FirstOrDefault(),
                     _title1,
                     "Description",
                     DisciplineType.MDP,
@@ -237,7 +238,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
 
                 _invitation3 = new Invitation(
                     TestPlant,
-                    _projectName2,
+                    _projectName2.FirstOrDefault(),
                     _title2,
                     "Description",
                     DisciplineType.DP,
@@ -272,7 +273,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
                 var query = new GetInvitationsForExportQuery(_projectName);
 
                 var result = await dut.Handle(query, default);
@@ -287,7 +288,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
 
@@ -301,7 +302,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, new Sorting(SortingDirection.Asc, SortingProperty.PunchOutDateUtc));
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -316,7 +317,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, new Sorting(SortingDirection.Desc, SortingProperty.PunchOutDateUtc));
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -334,7 +335,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -350,7 +351,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -366,7 +367,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -394,7 +395,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                    new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -415,7 +416,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -431,7 +432,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -447,7 +448,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -463,7 +464,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -479,7 +480,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -495,7 +496,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -511,7 +512,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -527,7 +528,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -544,7 +545,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -560,7 +561,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -577,7 +578,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -592,7 +593,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -608,7 +609,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -624,7 +625,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -640,7 +641,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -656,7 +657,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -672,7 +673,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -688,7 +689,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation2.Id, result.Data.Invitations.First().Id);
@@ -706,7 +707,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation3.Id, result.Data.Invitations.First().Id);
@@ -724,7 +725,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation3.Id, result.Data.Invitations.First().Id);
@@ -742,7 +743,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation2.Id, result.Data.Invitations.First().Id);
@@ -757,7 +758,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
 
@@ -772,7 +773,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
 
@@ -788,7 +789,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
         private void AssertUsedFilter(UsedFilterDto usedFilter)
         {
             Assert.AreEqual(TestPlant, usedFilter.Plant);
-            Assert.AreEqual(_projectName, usedFilter.ProjectName);
+            Assert.AreEqual(_projectName.FirstOrDefault(), usedFilter.ProjectName);
             Assert.IsNull(usedFilter.IpoIdStartsWith);
             Assert.IsNull(usedFilter.IpoTitleStartWith);
             Assert.IsNull(usedFilter.McPkgNoStartsWith);

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Authorizations/AccessValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.Tests/Authorizations/AccessValidatorTests.cs
@@ -35,6 +35,7 @@ using Equinor.ProCoSys.IPO.WebApi.Misc;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Linq;
 
 namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
 {
@@ -47,8 +48,9 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         private Mock<ICurrentUserProvider> _currentUserProviderMock;
         private const int _invitationIdWithAccessToProject = 1;
         private const int _invitationIdWithoutAccessToProject = 2;
-        private const string _projectWithAccess = "TestProjectWithAccess";
-        private const string _projectWithoutAccess = "TestProjectWithoutAccess";
+
+        private List<string> _projectWithAccess = new List<string> { "TestProjectWithAccess" };
+        private List<string> _projectWithoutAccess = new List<string> { "TestProjectWithoutAccess" };
 
         [TestInitialize]
         public void Setup()
@@ -57,14 +59,14 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
 
             _projectAccessCheckerMock = new Mock<IProjectAccessChecker>();
 
-            _projectAccessCheckerMock.Setup(p => p.HasCurrentUserAccessToProject(_projectWithoutAccess)).Returns(false);
-            _projectAccessCheckerMock.Setup(p => p.HasCurrentUserAccessToProject(_projectWithAccess)).Returns(true);
+            _projectAccessCheckerMock.Setup(p => p.HasCurrentUserAccessToProject(_projectWithoutAccess.FirstOrDefault())).Returns(false);
+            _projectAccessCheckerMock.Setup(p => p.HasCurrentUserAccessToProject(_projectWithAccess.FirstOrDefault())).Returns(true);
 
             var invitationHelperMock = new Mock<IInvitationHelper>();
             invitationHelperMock.Setup(p => p.GetProjectNameAsync(_invitationIdWithAccessToProject))
-                .Returns(Task.FromResult(_projectWithAccess));
+                .Returns(Task.FromResult(_projectWithAccess.FirstOrDefault()));
             invitationHelperMock.Setup(p => p.GetProjectNameAsync(_invitationIdWithoutAccessToProject))
-                .Returns(Task.FromResult(_projectWithoutAccess));
+                .Returns(Task.FromResult(_projectWithoutAccess.FirstOrDefault()));
 
             _loggerMock = new Mock<ILogger<AccessValidator>>();
 
@@ -88,7 +90,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
                 null,
                 new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
                 new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _projectWithAccess,
+                _projectWithAccess.FirstOrDefault(),
                 DisciplineType.DP,
                 null,
                 null,
@@ -111,7 +113,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
                 null,
                 new DateTime(2020, 9, 1, 12, 0, 0, DateTimeKind.Utc),
                 new DateTime(2020, 9, 1, 13, 0, 0, DateTimeKind.Utc),
-                _projectWithoutAccess,
+                _projectWithoutAccess.FirstOrDefault(),
                 DisciplineType.DP,
                 null,
                 null,
@@ -625,7 +627,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         {
             // Arrange
             var command = new CreateSavedFilterCommand(
-                _projectWithAccess,
+                _projectWithAccess.FirstOrDefault(),
                 "title",
                 "criteria",
                 false);
@@ -642,7 +644,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         {
             // Arrange
             var command = new CreateSavedFilterCommand(
-                _projectWithoutAccess,
+                _projectWithoutAccess.FirstOrDefault(),
                 "title",
                 "criteria",
                 false);
@@ -720,7 +722,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetCommPkgsInProjectQuery_ShouldReturnTrue_WhenAccessToProject()
         {
             // Arrange
-            var query = new GetCommPkgsInProjectQuery(_projectWithAccess, null, 10, 0);
+            var query = new GetCommPkgsInProjectQuery(_projectWithAccess.FirstOrDefault(), null, 10, 0);
 
             // act
             var result = await _dut.ValidateAsync(query);
@@ -733,7 +735,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetCommPkgsInProjectQuery_ShouldReturnFalse_WhenNoAccessToProject()
         {
             // Arrange
-            var query = new GetCommPkgsInProjectQuery(_projectWithoutAccess, null, 10, 0);
+            var query = new GetCommPkgsInProjectQuery(_projectWithoutAccess.FirstOrDefault(), null, 10, 0);
             
             // act
             var result = await _dut.ValidateAsync(query);
@@ -832,7 +834,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetInvitationsByCommPkgNoQuery_ShouldReturnTrue_WhenAccessToProject()
         {
             // Arrange
-            var query = new GetInvitationsByCommPkgNoQuery("commpkg", _projectWithAccess);
+            var query = new GetInvitationsByCommPkgNoQuery("commpkg", _projectWithAccess.FirstOrDefault());
 
             // act
             var result = await _dut.ValidateAsync(query);
@@ -845,7 +847,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetInvitationsByCommPkgNoQuery_ShouldReturnFalse_WhenNoAccessToProject()
         {
             // Arrange
-            var query = new GetInvitationsByCommPkgNoQuery("commpkg", _projectWithoutAccess);
+            var query = new GetInvitationsByCommPkgNoQuery("commpkg", _projectWithoutAccess.FirstOrDefault());
 
             // act
             var result = await _dut.ValidateAsync(query);
@@ -860,7 +862,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetInvitationsByCommPkgNosQuery_ShouldReturnTrue_WhenAccessToProject()
         {
             // Arrange
-            var query = new GetLatestMdpIpoStatusOnCommPkgsQuery(new List<string> {"commpkg"}, _projectWithAccess);
+            var query = new GetLatestMdpIpoStatusOnCommPkgsQuery(new List<string> {"commpkg"}, _projectWithAccess.FirstOrDefault());
 
             // act
             var result = await _dut.ValidateAsync(query);
@@ -873,7 +875,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetInvitationsByCommPkgNosQuery_ShouldReturnFalse_WhenNoAccessToProject()
         {
             // Arrange
-            var query = new GetLatestMdpIpoStatusOnCommPkgsQuery(new List<string> { "commpkg" }, _projectWithoutAccess);
+            var query = new GetLatestMdpIpoStatusOnCommPkgsQuery(new List<string> { "commpkg" }, _projectWithoutAccess.FirstOrDefault());
 
             // act
             var result = await _dut.ValidateAsync(query);
@@ -888,7 +890,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetMcPkgsUnderCommPkgInProjectQuery_ShouldReturnTrue_WhenAccessToProject()
         {
             // Arrange
-            var query = new GetMcPkgsUnderCommPkgInProjectQuery(_projectWithAccess, null);
+            var query = new GetMcPkgsUnderCommPkgInProjectQuery(_projectWithAccess.FirstOrDefault(), null);
             
             // act
             var result = await _dut.ValidateAsync(query);
@@ -901,7 +903,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Tests.Authorizations
         public async Task ValidateAsync_OnGetMcPkgsUnderCommPkgInProjectQuery_ShouldReturnFalse_WhenNoAccessToProject()
         {
             // Arrange
-            var query = new GetMcPkgsUnderCommPkgInProjectQuery(_projectWithoutAccess, null);
+            var query = new GetMcPkgsUnderCommPkgInProjectQuery(_projectWithoutAccess.FirstOrDefault(), null);
             
             // act
             var result = await _dut.ValidateAsync(query);


### PR DESCRIPTION
Endpoints Invitations and ExportInvitationsToExcel now support null for projectName. 
If no projectName is given in querystring, the query for IPOs is executed cross-project for the whole plant.
It's also possible to sort by projectName now.

[AB#94186](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/94186)