### PR TITLE
94270 - Add ClassLevelCascadeMode where relevant

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/AcceptPunchOut/AcceptPunchOutCommandValidator.cs
@@ -12,6 +12,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.AcceptPunchOut
         public AcceptPunchOutCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CompletePunchOut/CompletePunchOutCommandValidator.cs
@@ -12,6 +12,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CompletePunchOut
         public CompletePunchOutCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CreateInvitation/CreateInvitationCommandValidator.cs
@@ -11,6 +11,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CreateInvitation
         public CreateInvitationCommandValidator(IInvitationValidator invitationValidator)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 //input validators

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditInvitation/EditInvitationCommandValidator.cs
@@ -14,6 +14,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditInvitation
         public EditInvitationCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 //input validators

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditParticipants/EditParticipantsCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/EditParticipants/EditParticipantsCommandValidator.cs
@@ -14,6 +14,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.EditParticipants
         public EditParticipantsCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 //input validators

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateAttendedStatusAndNotesOnParticipants/UpdateAttendedStatusAndNotesOnParticipantsCommandValidator.cs
@@ -12,6 +12,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateAttendedStatusAn
         public UpdateAttendedStatusAndNotesOnParticipantsCommandValidator(IInvitationValidator invitationValidator, IRowVersionValidator rowVersionValidator)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, cancellationToken) => BeAnExistingInvitation(command.InvitationId, cancellationToken))

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UploadAttachment/UploadAttachmentCommandValidator.cs
@@ -15,6 +15,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UploadAttachment
         public UploadAttachmentCommandValidator(IInvitationValidator invitationValidator, IOptionsMonitor<BlobStorageOptions> options)
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(x => x)
                 .NotNull();

--- a/src/Equinor.ProCoSys.IPO.Command/PersonCommands/CreatePerson/CreatePersonCommandValidator.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/PersonCommands/CreatePerson/CreatePersonCommandValidator.cs
@@ -8,6 +8,7 @@ namespace Equinor.ProCoSys.IPO.Command.PersonCommands.CreatePerson
         public CreatePersonCommandValidator()
         {
             RuleLevelCascadeMode = CascadeMode.Stop;
+            ClassLevelCascadeMode = CascadeMode.Stop;
 
             RuleFor(x => x.Email)
                 .NotEmpty()


### PR DESCRIPTION
After updating FluentValidation we have to specify RuleLevel and ClassLevel CascadeMode. Where we have more than one "RuleFor" we must also specify ClassLevelCascadeMode to keep same validating pattern as before with CascadeMode.Stop.

[AB#94270](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/94270)