### PR TITLE
95832 - Include accepted IPOs when getting outstanding

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposForCurrentPersonQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetOutstandingIpos/GetOutstandingIposForCurrentPersonQueryHandler.cs
@@ -73,8 +73,9 @@ namespace Equinor.ProCoSys.IPO.Query.GetOutstandingIpos
                     currentUsersOutstandingInvitations.Select(invitation =>
                     {
                         var organization = invitation.Participants.First(p =>
-                            p.AzureOid == currentUserOid ||
-                            currentUsersFunctionalRoleCodes.Contains(p.FunctionalRoleCode)).Organization;
+                            p.SignedBy == null &&
+                            (p.AzureOid == currentUserOid ||
+                            currentUsersFunctionalRoleCodes.Contains(p.FunctionalRoleCode))).Organization;
                         return new OutstandingIpoDetailsDto
                         {
                             InvitationId = invitation.Id,


### PR DESCRIPTION
Signers should get IPOs that they need to sign even if they are accepted.

[AB#95832](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/95832)