### PR TITLE
95690 removed useless drop index from migration

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20221003204732_AddIndexForInvitationAndParticipant.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Migrations/20221003204732_AddIndexForInvitationAndParticipant.cs
@@ -9,10 +9,6 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Participants_InvitationId",
-                table: "Participants");
-
             migrationBuilder.CreateIndex(
                 name: "IX_Participants_InvitationId_Plant",
                 table: "Participants",
@@ -35,12 +31,7 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Migrations
 
             migrationBuilder.DropIndex(
                 name: "IX_Invitations_Plant",
-                table: "Invitations");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Participants_InvitationId",
-                table: "Participants",
-                column: "InvitationId");
+                table: "Invitations");       
         }
     }
 }


### PR DESCRIPTION
The index does not exist so migration fails
[AB#95690](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/95690)