### PR TITLE
101227 - Revert using oid instead of email

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/InvitationHelper.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/InvitationHelper.cs
@@ -125,27 +125,13 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands
             table += $"</table>";
             return table;
         }
-
         private static ParticipantIdentifier CreateParticipantIdentifier(ProCoSysPerson person)
-        {
-            if (IsValidGuid(person.AzureOid))
-            {
-                return new ParticipantIdentifier(new Guid(person.AzureOid));
-            }
-            if (IsValidEmail(person.Email))
-            {
-                return new ParticipantIdentifier(person.Email);
-            }
-
-            throw new IpoValidationException(
-                "Person does not have valid Oid [" + person.AzureOid + "] or Email [" + person.Email + "]");
-        }
+            => IsValidEmail(person.Email) ?
+                new ParticipantIdentifier(person.Email) :
+                new ParticipantIdentifier(new Guid(person.AzureOid));
 
         private static ParticipantType GetParticipantType(bool required)
             => required ? ParticipantType.Required : ParticipantType.Optional;
-
-        private static bool IsValidGuid(string guid)
-            => Guid.TryParse(guid, out _);
 
         private static bool IsValidEmail(string email)
             => new EmailAddressAttribute().IsValid(email);


### PR DESCRIPTION
Revert using oid instead of email when creating meeting, as some users use another email than the one connected to their oid

[AB#101227](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/101227)