### PR TITLE
Bug 101259 - Prevent out-of-memory exception in excel-export

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/PersonAggregate/Person.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/PersonAggregate/Person.cs
@@ -39,6 +39,8 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.PersonAggregate
         public DateTime? ModifiedAtUtc { get; private set; }
         public int? ModifiedById { get; private set; }
 
+        public string GetFullName() => $"{FirstName} {LastName}";
+
         public void SetModified(Person modifiedBy)
         {
             ModifiedAtUtc = TimeService.UtcNow;

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExcelQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExcelQueryHandler.cs
@@ -102,7 +102,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
                     $"{dto.CreatedBy.FirstName} {dto.CreatedBy.LastName}")).ToList();
         }
 
-        private IList<ExportParticipantDto> CreateParticipantsDtoForInvitation(Invitation invitationWithIncludes)
+        private IList<ExportParticipantDto> CreateParticipantDtosForInvitation(Invitation invitationWithIncludes)
             => invitationWithIncludes.Participants.Select(participant => new ExportParticipantDto(
                 participant.Id,
                 participant.Organization.ToString(),
@@ -215,7 +215,7 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationsQueries.GetInvitationsForExpo
                     invitation.CreatedAtUtc,
                     organizer.GetFullName()
                 );
-                exportInvitationDto.Participants.AddRange(CreateParticipantsDtoForInvitation(invitation));
+                exportInvitationDto.Participants.AddRange(CreateParticipantDtosForInvitation(invitation));
                 exportInvitations.Add(exportInvitationDto);
             }
             await FillSignedByAsync(exportInvitations);

--- a/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Equinor.ProCoSys.IPO.WebApi.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.100.3" />
+    <PackageReference Include="ClosedXML" Version="0.101.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
     <PackageReference Include="Fusion.Integration" Version="6.10.2" />
     <PackageReference Include="Fusion.Integration.Meeting" Version="6.0.2" />

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQueryHandlerTests.cs
@@ -15,7 +15,6 @@ using Equinor.ProCoSys.IPO.Test.Common;
 using Equinor.ProCoSys.IPO.Test.Common.ExtensionMethods;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using ServiceResult;
 
 namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsForExport
@@ -26,7 +25,6 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
         private Invitation _invitation1;
         private Invitation _invitation2;
         private Invitation _invitation3;
-        private Mock<IPersonRepository> _personRepositoryMock;
         private const int _participantId1 = 10;
         private Person _currentPerson;
 
@@ -236,11 +234,6 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 _currentPerson = new Person(_currentUserOid, "firstname", "lastname", "testusername", null);
                 _currentPerson.SetProtectedIdForTesting(_participantId1);
 
-                _personRepositoryMock = new Mock<IPersonRepository>();
-                _personRepositoryMock
-                    .Setup(x => x.GetByIdAsync(It.IsAny<int>()))
-                    .Returns(Task.FromResult(_currentPerson));
-
                 var startTime3 = _timeProvider.UtcNow.AddWeeks(2);
 
                 _invitation3 = new Invitation(
@@ -283,7 +276,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context =
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
                 var query = new GetInvitationsForExportQuery(_projectName);
 
                 var result = await dut.Handle(query, default);
@@ -298,7 +291,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
 
@@ -312,7 +305,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, new Sorting(SortingDirection.Asc, SortingProperty.PunchOutDateUtc));
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -327,7 +320,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, new Sorting(SortingDirection.Desc, SortingProperty.PunchOutDateUtc));
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -345,7 +338,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -361,7 +354,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -377,7 +370,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -405,7 +398,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                    new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -426,7 +419,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -442,7 +435,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -458,7 +451,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -474,7 +467,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -490,7 +483,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -506,7 +499,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -522,7 +515,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -538,7 +531,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -555,7 +548,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -571,7 +564,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -588,7 +581,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -603,7 +596,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -619,7 +612,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 1);
@@ -635,7 +628,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -651,7 +644,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -667,7 +660,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 0);
@@ -683,7 +676,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, null, filter);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 AssertCount(result.Data, 2);
@@ -699,7 +692,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation2.Id, result.Data.Invitations.First().Id);
@@ -717,7 +710,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation3.Id, result.Data.Invitations.First().Id);
@@ -735,7 +728,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation3.Id, result.Data.Invitations.First().Id);
@@ -753,7 +746,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
                 new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2, sorting);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
                 Assert.AreEqual(_invitation2.Id, result.Data.Invitations.First().Id);
@@ -768,7 +761,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName2);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
 
@@ -783,7 +776,7 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             using (var context = new IPOContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var query = new GetInvitationsForExportQuery(_projectName);
-                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _personRepositoryMock.Object, _currentUserProvider, _permissionCache);
+                var dut = new GetInvitationsForExportQueryHandler(context, _plantProvider, _currentUserProvider, _permissionCache);
 
                 var result = await dut.Handle(query, default);
 

--- a/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Query.Tests/GetInvitationsQueries/GetInvitationsForExport/GetInvitationsForExportQueryHandlerTests.cs
@@ -52,7 +52,6 @@ namespace Equinor.ProCoSys.IPO.Query.Tests.GetInvitationsQueries.GetInvitationsF
             {
                 context.Projects.Add(_project1);
                 context.Projects.Add(_project2);
-                context.SaveChangesAsync().Wait();
 
                 const string description = "Description";
 

--- a/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
@@ -27,7 +27,6 @@ namespace Equinor.ProCoSys.IPO.Test.Common
         protected const string Criteria = "Fcriteria";
         protected SavedFilter _savedFilter;
         protected readonly Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
-        protected readonly Guid _exportUserOid = new Guid("12345678-1234-1234-1234-123456789124");
         protected DbContextOptions<IPOContext> _dbContextOptions;
         protected Mock<IPlantProvider> _plantProviderMock;
         protected IPlantProvider _plantProvider;
@@ -47,7 +46,7 @@ namespace Equinor.ProCoSys.IPO.Test.Common
             _plantProviderMock = new Mock<IPlantProvider>();
             _plantProviderMock.SetupGet(x => x.Plant).Returns(TestPlant);
             _plantProvider = _plantProviderMock.Object;
-
+            
             _personApiServiceMock = new Mock<IPersonApiService>();
             _personApiService = _personApiServiceMock.Object;
 
@@ -76,7 +75,6 @@ namespace Equinor.ProCoSys.IPO.Test.Common
                 if (context.Persons.SingleOrDefault(p => p.Oid == _currentUserOid) == null)
                 {
                     var person = AddPerson(context, _currentUserOid, "Ole", "Lukkøye", "ol", "ol@pcs.pcs");
-                    var personForExportTests = AddPerson(context, _exportUserOid, "firstname", "lastname", "testusername", "test@test.com", 10);
                     AddSavedFiltersToPerson(context, person);
                     AddProject(context, Project);
                 }
@@ -93,15 +91,9 @@ namespace Equinor.ProCoSys.IPO.Test.Common
             return context.Projects.Single(x => x.Id == projectId);
         }
 
-        protected Person AddPerson(IPOContext context, Guid oid, string firstName, string lastName, string userName, string email, int? id = null)
+        protected Person AddPerson(IPOContext context, Guid oid, string firstName, string lastName, string userName, string email)
         {
             var person = new Person(oid, firstName, lastName, userName, email);
-
-            if (id != null)
-            {
-                person.SetProtectedIdForTesting((int)id);
-            }
-
             context.Persons.Add(person);
             context.SaveChangesAsync().Wait();
             return person;

--- a/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Test.Common/ReadOnlyTestsBase.cs
@@ -27,6 +27,7 @@ namespace Equinor.ProCoSys.IPO.Test.Common
         protected const string Criteria = "Fcriteria";
         protected SavedFilter _savedFilter;
         protected readonly Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
+        protected readonly Guid _exportUserOid = new Guid("12345678-1234-1234-1234-123456789124");
         protected DbContextOptions<IPOContext> _dbContextOptions;
         protected Mock<IPlantProvider> _plantProviderMock;
         protected IPlantProvider _plantProvider;
@@ -46,7 +47,7 @@ namespace Equinor.ProCoSys.IPO.Test.Common
             _plantProviderMock = new Mock<IPlantProvider>();
             _plantProviderMock.SetupGet(x => x.Plant).Returns(TestPlant);
             _plantProvider = _plantProviderMock.Object;
-            
+
             _personApiServiceMock = new Mock<IPersonApiService>();
             _personApiService = _personApiServiceMock.Object;
 
@@ -75,6 +76,7 @@ namespace Equinor.ProCoSys.IPO.Test.Common
                 if (context.Persons.SingleOrDefault(p => p.Oid == _currentUserOid) == null)
                 {
                     var person = AddPerson(context, _currentUserOid, "Ole", "Lukkøye", "ol", "ol@pcs.pcs");
+                    var personForExportTests = AddPerson(context, _exportUserOid, "firstname", "lastname", "testusername", "test@test.com", 10);
                     AddSavedFiltersToPerson(context, person);
                     AddProject(context, Project);
                 }
@@ -91,9 +93,15 @@ namespace Equinor.ProCoSys.IPO.Test.Common
             return context.Projects.Single(x => x.Id == projectId);
         }
 
-        protected Person AddPerson(IPOContext context, Guid oid, string firstName, string lastName, string userName, string email)
+        protected Person AddPerson(IPOContext context, Guid oid, string firstName, string lastName, string userName, string email, int? id = null)
         {
             var person = new Person(oid, firstName, lastName, userName, email);
+
+            if (id != null)
+            {
+                person.SetProtectedIdForTesting((int)id);
+            }
+
             context.Persons.Add(person);
             context.SaveChangesAsync().Wait();
             return person;


### PR DESCRIPTION
Refactored to run a single db-query to fetch all relevant persons in a list of IPOs - instead of querying for a single person in a for-loop. Should better performance and avoid OOM-exception.

[AB#101259](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/101259)