### PR TITLE
105637 - Only handle CertificateAccepted events in command

### DIFF
--- a/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/CertificateEventProcessorService.cs
+++ b/src/Equinor.ProCoSys.IPO.WebApi/Synchronization/CertificateEventProcessorService.cs
@@ -6,6 +6,7 @@ using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Common.Telemetry;
 using Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateRfocAcceptedStatus;
 using Equinor.ProCoSys.PcsServiceBus;
+using Equinor.ProCoSys.PcsServiceBus.Enums;
 using Equinor.ProCoSys.PcsServiceBus.Topics;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -64,7 +65,7 @@ namespace Equinor.ProCoSys.IPO.WebApi.Synchronization
 
         private async Task HandleRfocAcceptedIfRelevantAsync(CertificateTopic certificateEvent)
         {
-            if (certificateEvent.CertificateType == "RFOC")
+            if (certificateEvent.CertificateStatus == CertificateStatus.Accepted && certificateEvent.CertificateType == "RFOC")
             {
                 var result = await _mediator.Send(new UpdateRfocAcceptedCommand(
                     certificateEvent.ProjectName,


### PR DESCRIPTION
[AB#105637](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/105637)

Voided events are resulting in dead letters. Fix until PR for handling voided events is ready.