### PR TITLE
107109 - fix error resulting in deadletter

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateRfocAcceptedStatus/UpdateRfocAcceptedCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateRfocAcceptedStatus/UpdateRfocAcceptedCommandHandler.cs
@@ -109,11 +109,15 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateRfocAcceptedStat
 
             foreach (var mcPkgInfo in mcPkgs)
             {
-                var mcPkg = _invitationRepository.GetMcPkg(project.Name, mcPkgInfo.Item2, mcPkgInfo.Item1);
-                if (mcPkg != null)
+                var mcPkgList = _invitationRepository.GetMcPkgs(project.Name, mcPkgInfo.Item2, mcPkgInfo.Item1);
+                if (!mcPkgs.IsNullOrEmpty())
                 {
                     certificate ??= await GetOrCreateCertificateAsync(request.ProCoSysGuid, project, cancellationToken);
-                    certificate.AddMcPkgRelation(mcPkg);
+                    foreach (var mcPkg in mcPkgList)
+                    {
+                        certificate.AddMcPkgRelation(mcPkg);
+                    }
+                    
                 }
             }
 

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateRfocAcceptedStatus/UpdateRfocAcceptedCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateRfocAcceptedStatus/UpdateRfocAcceptedCommandHandler.cs
@@ -110,7 +110,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateRfocAcceptedStat
             foreach (var mcPkgInfo in mcPkgs)
             {
                 var mcPkgList = _invitationRepository.GetMcPkgs(project.Name, mcPkgInfo.Item2, mcPkgInfo.Item1);
-                if (!mcPkgs.IsNullOrEmpty())
+                if (!mcPkgList.IsNullOrEmpty())
                 {
                     certificate ??= await GetOrCreateCertificateAsync(request.ProCoSysGuid, project, cancellationToken);
                     foreach (var mcPkg in mcPkgList)

--- a/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/IInvitationRepository.cs
+++ b/src/Equinor.ProCoSys.IPO.Domain/AggregateModels/InvitationAggregate/IInvitationRepository.cs
@@ -18,6 +18,6 @@ namespace Equinor.ProCoSys.IPO.Domain.AggregateModels.InvitationAggregate
         void UpdateRfocStatuses(string projectName, IList<string> commPkgNos, IList<Tuple<string, string>> mcPkgs);
         IList<Invitation> GetInvitationsForSynchronization();
         IList<CommPkg> GetCommPkgs(string projectName, IList<string> commPkgNos);
-        McPkg GetMcPkg(string projectName, string commPkgNo, string mcPkgNo);
+        IList<McPkg> GetMcPkgs(string projectName, string commPkgNo, string mcPkgNo);
     }
 }

--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
@@ -154,7 +154,7 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Repositories
             return _context.CommPkgs.Where(c => commPkgNos.Contains(c.CommPkgNo) && c.ProjectId == project.Id).ToList();
         }
 
-        public McPkg GetMcPkg(string projectName, string commPkgNo, string mcPkgNo)
+        public IList<McPkg> GetMcPkgs(string projectName, string commPkgNo, string mcPkgNo)
         {
             var project = _context.Projects.SingleOrDefault(x => x.Name.Equals(projectName));
 
@@ -163,7 +163,7 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Repositories
                 throw new NullReferenceException($"Project not found. {projectName}.");
             }
 
-            return _context.McPkgs.SingleOrDefault(mc => mc.McPkgNo == mcPkgNo && mc.CommPkgNo == commPkgNo && mc.ProjectId == project.Id);
+            return _context.McPkgs.Where(mc => mc.McPkgNo == mcPkgNo && mc.CommPkgNo == commPkgNo && mc.ProjectId == project.Id).ToList();
         }
 
         public void UpdateRfocStatuses(string projectName, IList<string> commPkgNos, IList<Tuple<string, string>> mcPkgs)

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateRfocAccepted/UpdateRfocAcceptedCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UpdateRfocAccepted/UpdateRfocAcceptedCommandHandlerTests.cs
@@ -184,8 +184,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UpdateRfocAccept
         public async Task HandlingUpdateRfocStatusCommand_ShouldCreateCertificateAndCreateRelation()
         {
             _invitationRepositoryMock
-                .Setup(r => r.GetMcPkg(_projectName, _commPkgNo, _mcPkgNo))
-                .Returns(new McPkg(_plant, _project, _commPkgNo, _mcPkgNo, "description", "1|2"));
+                .Setup(r => r.GetMcPkgs(_projectName, _commPkgNo, _mcPkgNo))
+                .Returns(new List<McPkg> { new McPkg(_plant, _project, _commPkgNo, _mcPkgNo, "description", "1|2") });
             var result = await _dut.Handle(_command, default);
 
             Assert.AreEqual(ServiceResult.ResultType.Ok, result.ResultType);

--- a/src/tests/Equinor.ProCoSys.IPO.Infrastructure.Tests/Repositories/InvitationRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Infrastructure.Tests/Repositories/InvitationRepositoryTests.cs
@@ -144,7 +144,7 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Tests.Repositories
                 null,
                 new List<McPkg> { _mcPkgCopy },
                 null);
-            _dpInviation.SetProtectedIdForTesting(InvitationWithMcPkgCopyId);
+            _dpInviationSameScope.SetProtectedIdForTesting(InvitationWithMcPkgCopyId);
             _dpInviationMove = new Invitation(
                 TestPlant,
                 _project1,
@@ -290,7 +290,7 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Tests.Repositories
         {
             var result = await _dut.GetAllAsync();
 
-            Assert.AreEqual(5, result.Count);
+            Assert.AreEqual(6, result.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
[AB#107109](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/107109)

Error in coding. Should not expect just a single mcpkg when searching for package with mcpkgno, commpkgno, and projectname, since the same mc package can be un multiple IPOs.