### PR TITLE
109792 - Unaccept and uncomplete bug for IPO Admins

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnAcceptPunchOut/UnAcceptPunchOutCommandHandler.cs
@@ -38,7 +38,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnAcceptPunchOut
             var hasAdminPrivilege = await InvitationHelper.HasIpoAdminPrivilegeAsync(_permissionCache, _plantProvider, _currentUserProvider);
             var participant = invitation.Participants.SingleOrDefault(p => 
                 p.SortKey == 1 && 
-                p.Organization == Organization.ConstructionCompany && 
+                p.Organization == Organization.ConstructionCompany &&
+                p.SignedAtUtc != null &&
                 (p.AzureOid == currentUserAzureOid || hasAdminPrivilege));
 
             if (participant == null || participant.FunctionalRoleCode != null)

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandler.cs
@@ -39,6 +39,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
             var participant = invitation.Participants.SingleOrDefault(p => 
                 p.SortKey == 0 && 
                 p.Organization == Organization.Contractor && 
+                p.SignedAtUtc != null &&
                 (p.AzureOid == currentUserAzureOid || hasAdminPrivilege));
 
             if (participant == null || participant.FunctionalRoleCode != null)

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandler.cs
@@ -38,7 +38,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UnCompletePunchOut
             var hasAdminPrivilege = await InvitationHelper.HasIpoAdminPrivilegeAsync(_permissionCache, _plantProvider, _currentUserProvider);
             var participant = invitation.Participants.SingleOrDefault(p => 
                 p.SortKey == 0 && 
-                p.Organization == Organization.Contractor && 
+                p.Organization == Organization.Contractor &&
                 p.SignedAtUtc != null &&
                 (p.AzureOid == currentUserAzureOid || hasAdminPrivilege));
 

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
@@ -90,6 +90,18 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
                 0);
             _invitation.AddParticipant(participant1);
             participant1.SetProtectedIdForTesting(_participantId);
+            var participant3 = new Participant(
+                _plant,
+                Organization.Contractor,
+                IpoParticipantType.Person,
+                _functionalRoleCode,
+                "kari",
+                "n",
+                "KariN",
+                "kari@test.com",
+                _azureOidForCurrentUser,
+                0);
+            _invitation.AddParticipant(participant3);
 
             var participant2 = new Participant(
                 _plant,
@@ -174,7 +186,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
                 _plant, _azureOidNotForCurrentUser))
                 .Returns(Task.FromResult(permissions));
             Assert.AreEqual(IpoStatus.Completed, _invitation.Status);
-            var participant = _invitation.Participants.Single(p => p.Organization == Organization.Contractor);
+            var participant = _invitation.Participants.First(p => p.Organization == Organization.Contractor);
             Assert.IsNotNull(participant);
             Assert.IsNotNull(participant.SignedAtUtc);
             Assert.IsNotNull(participant.SignedBy);

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/UnCompletePunchOut/UnCompletePunchOutCommandHandlerTests.cs
@@ -144,7 +144,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.UnCompletePunchO
         public async Task UnCompletePunchOutCommand_ShouldUnCompletePunchOut()
         {
             Assert.AreEqual(IpoStatus.Completed, _invitation.Status);
-            var participant = _invitation.Participants.Single(p => p.Organization == Organization.Contractor);
+            var participant = _invitation.Participants.First(p => p.Organization == Organization.Contractor);
             Assert.IsNotNull(participant);
             Assert.IsNotNull(participant.SignedAtUtc);
             Assert.IsNotNull(participant.SignedBy);


### PR DESCRIPTION
[AB#109792](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/109792) 

Getting "sequence contains more than one element" on unaccept and unsign for IPO Admins, since there is more than one participant that matched the criteria. Fixed by also checking that participant row must be signed.