### PR TITLE
Fix test factory so it does not create two instances of WAF

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/FillRfocGuids/FillRfocGuidsCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/FillRfocGuids/FillRfocGuidsCommandHandler.cs
@@ -73,7 +73,8 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.FillRfocGuids
             //    _logger.LogInformation($"CommPkgs updated with RfocGuid: {commPkgsUpdatedCount}");
             //}
 
-            return new SuccessResult<Unit>(Unit.Value);
+            // return new SuccessResult<Unit>(Unit.Value);
+           return await Task.FromResult(new SuccessResult<Unit>(Unit.Value));
         }
 
         private async Task<int> HandleMcPkgsAsync(List<Invitation> invitations, Project project, CancellationToken token)

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using DocumentFormat.OpenXml.Office2010.Excel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests.Persons

--- a/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.WebApi.IntegrationTests/TestFactory.cs
@@ -164,8 +164,10 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            builder.ConfigureTestServices(services =>
-            {
+              builder.UseEnvironment(IntegrationTestEnvironment); 
+              builder.ConfigureAppConfiguration((context, conf) => conf.AddJsonFile(_configPath)); 
+              builder.ConfigureTestServices(services =>
+              {
                 services.AddAuthentication()
                     .AddScheme<IntegrationTestAuthOptions, IntegrationTestAuthHandler>(
                         IntegrationTestAuthHandler.TestAuthenticationScheme, opts => { });
@@ -318,23 +320,16 @@ namespace Equinor.ProCoSys.IPO.WebApi.IntegrationTests
 
             AddCreatorUser(accessablePlants, accessableProjects);
 
-            var webHostBuilder = WithWebHostBuilder(builder =>
-            {
-                builder.UseEnvironment(IntegrationTestEnvironment);
-                builder.ConfigureAppConfiguration((context, conf) => conf.AddJsonFile(_configPath));
-            });
-
-
             SetupProCoSysServiceMocks();
 
-            CreateAuthenticatedHttpClients(webHostBuilder);
+            CreateAuthenticatedHttpClients();
         }
 
-        private void CreateAuthenticatedHttpClients(WebApplicationFactory<Startup> webHostBuilder)
+        private void CreateAuthenticatedHttpClients()
         {
             foreach (var testUser in _testUsers.Values)
             {
-                testUser.HttpClient = webHostBuilder.CreateClient();
+                testUser.HttpClient = CreateClient();
 
                 if (testUser.Profile != null)
                 {


### PR DESCRIPTION
WithBuilder() Creates a new WebAplicationFactory. This is not needed since we already have an instance. Can call CreateClient directly on that