### PR TITLE
Fixed the issue related to ProjectGuid. It was an unneccessary filter…

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
+++ b/src/Equinor.ProCoSys.IPO.Infrastructure/Repositories/InvitationRepository.cs
@@ -38,7 +38,7 @@ namespace Equinor.ProCoSys.IPO.Infrastructure.Repositories
             {
                 return false;
             }
-            return _context.CommPkgs.Any(commPkg => commPkg.CommPkgGuid == commPkgGuid && commPkg.ProjectId == toProject.Id);
+            return _context.CommPkgs.Any(commPkg => commPkg.CommPkgGuid == commPkgGuid);
         }
 
         public void UpdateCommPkgOnInvitations(Guid commPkgGuid, string description)


### PR DESCRIPTION
…ing on to project when retrieving commpkg. This resultated in empty result set when we wanted the object references in the message.