### PR TITLE
GH00627: Not providing exception to log methods which we do not want …

### DIFF
--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandler.cs
@@ -79,12 +79,18 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.CancelPunchOut
             {
                 if (e.Code.ToString().ToUpperInvariant() == "FORBIDDEN")
                 {
-                    _logger.LogError(e, $"Unable to cancel outlook meeting for IPO.");
+                    _logger.LogError($"Unable to cancel outlook meeting for IPO. Inconsistency between Fusion and IPO regarding rights for meeting with id {meetingId}. Stack trace: {e.StackTrace}");
                 }
                 else
                 {
                     throw;
                 }
+            }
+            catch (ArgumentException e)
+            {
+                _logger.LogWarning($"Unable to cancel outlook meeting in Fusion IPO with id {meetingId}. " +
+                                      $"E.g. the reason could be that Fusion was unavailable/ unstable at creation time. " +
+                                      $"It will still be cancelled in IPO though.");
             }
         }
     }

--- a/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateRfocAcceptedStatus/UpdateRfocAcceptedCommandHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Command/InvitationCommands/UpdateRfocAcceptedStatus/UpdateRfocAcceptedCommandHandler.cs
@@ -72,7 +72,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateRfocAcceptedStat
             if (certificateMcPkgsModel == null)
             {
                 var error = $"Certificate {request.ProCoSysGuid} McPkg scope not found";
-                _logger.LogError(error);
+                _logger.LogWarning(error);
                 return new NotFoundResult<Unit>(error);
             }
 
@@ -81,7 +81,7 @@ namespace Equinor.ProCoSys.IPO.Command.InvitationCommands.UpdateRfocAcceptedStat
             if (certificateCommPkgsModel == null)
             {
                 var error = $"Certificate {request.ProCoSysGuid} CommPkg scope not found";
-                _logger.LogError(error);
+                _logger.LogWarning(error);
                 return new NotFoundResult<Unit>(error);
             }
 

--- a/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.IPO.Query/GetInvitationById/GetInvitationByIdQueryHandler.cs
@@ -69,17 +69,20 @@ namespace Equinor.ProCoSys.IPO.Query.GetInvitationById
             {
                 meeting = await _meetingClient.GetMeetingAsync(invitation.MeetingId,
                     query => query.ExpandInviteBodyHtml().ExpandProperty("participants.outlookstatus"));
-                LogFusionMeeting(meeting);
+                if (meeting != null)
+                {
+                    LogFusionMeeting(meeting);
+                }
             }
             catch (NotAuthorizedError e)
             {
-                _logger.LogWarning(e, $"Fusion meeting not authorized. MeetingId={invitation.MeetingId}");
+                _logger.LogWarning($"Fusion meeting not authorized. MeetingId={invitation.MeetingId}");
             }
             catch (MeetingApiException e)
             {
                 if (e.Code == ErrorCode.Forbidden)
                 {
-                    _logger.LogInformation(e, $"Fusion meeting: The user does not have access to retrieve this meeting. MeetingId={invitation.MeetingId}");
+                    _logger.LogInformation($"Fusion meeting: The user does not have access to retrieve this meeting. MeetingId={invitation.MeetingId} Stack trace: {e.StackTrace}");
                 }
                 else
                 {

--- a/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.IPO.Command.Tests/InvitationCommands/CancelPunchOut/CancelPunchOutCommandHandlerTests.cs
@@ -179,7 +179,7 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
             var result = await _dut.Handle(_command, default);
 
             // Assert
-            Func<object, Type, bool> state = (v, t) => v.ToString().CompareTo("Unable to cancel outlook meeting for IPO.") == 0;
+            Func<object, Type, bool> state = (v, t) => v.ToString().CompareTo("Unable to cancel outlook meeting for IPO.") == 1;
 
             Assert.AreEqual(ServiceResult.ResultType.Ok, result.ResultType);
 
@@ -188,8 +188,8 @@ namespace Equinor.ProCoSys.IPO.Command.Tests.InvitationCommands.CancelPunchOut
                     It.Is<LogLevel>(l => l == LogLevel.Error),
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => state(v, t)),
-                    It.IsAny<Exception>(),
-                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+                    It.IsAny<Exception?>(),
+                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)), Times.Once);
         }
 
         [TestMethod]


### PR DESCRIPTION
…to appear under exceptions in AI. Allowing cancellation of IPO's which does not have a counterpart in Fusion in some cases.
https://github.com/equinor/cc-toolbox/issues/627
